### PR TITLE
Clarify prereqs

### DIFF
--- a/docs/_documentations/installlocally.md
+++ b/docs/_documentations/installlocally.md
@@ -20,9 +20,8 @@ Codewind can be installed locally into Eclipse or into Visual Studio Code (VS Co
 * Linux or macOS, on x86_64 architecture only
 * [Visual Studio Code](https://code.visualstudio.com/) or [Eclipse IDE for Java EE Developers](https://www.eclipse.org/downloads/packages/release/)
 * [Git](https://git-scm.com/)
-* [Docker Desktop for Mac](https://hub.docker.com/editions/community/docker-ce-desktop-mac) **Version 17.06 minimum**
-* [Docker Compose](https://docs.docker.com/compose/install/)
-* On Linux, follow the post-installation steps to [run Docker as a non-root user](https://docs.docker.com/engine/installation/linux/linux-postinstall/).
+* On macOS, [Docker Desktop for Mac](https://hub.docker.com/editions/community/docker-ce-desktop-mac) **Version 17.06 minimum**
+* On Linux, [Docker Compose](https://docs.docker.com/compose/install/), and then follow the post-installation steps to [run Docker as a non-root user](https://docs.docker.com/engine/installation/linux/linux-postinstall/).
 
 ## Prerequisites for Windows
 * Windows 10 and Windows Server 2016 are supported.

--- a/docs/_documentations/installlocally.md
+++ b/docs/_documentations/installlocally.md
@@ -40,7 +40,7 @@ To install Codewind for VS Code, see [Getting Started: Codewind for VS Code](mdt
 
 ## Installing into Eclipse
 
-To install Codewind for VS Code, see [Getting Started: Codewind for Eclipse](mdteclipsegettingstarted.html)
+To install Codewind for Eclipse, see [Getting Started: Codewind for Eclipse](mdteclipsegettingstarted.html)
 
 ***
 ## Need help?


### PR DESCRIPTION
Under our prereqs page https://www.eclipse.org/codewind/installlocally.html we list Docker Compose as a prereq (but not for windows)

I think we should call out Linux and MacOS separately as Docker Compose is not a prereq for MacOS as its included in the Docker Destop for Mac install. Its only an additional install prereq when using Linux.

This PR to resolve the above. 