### PR TITLE
Adding info about ECA and associating your profile and ID

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,22 @@
 ## Contributing
 Thank you for your interest in contributing to Codewind. We welcome your additions to this project.
 
-#### Adding contributions
-- See the [Codewind GitHub Workflows](https://wiki.eclipse.org/Codewind_GitHub_Workflows) wiki.
+#### Signing the Eclipse Contributor Agreement (ECA)
+Before you can contribute to any Eclipse project, you need to sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php).
+1. To verify that you signed the ECA, sign in to [https://accounts.eclipse.org/ your Eclipse account].
+2. View your **Status** and make sure that a check mark appears with the **Eclipse Contributor Agreement**.
+3. If the check mark does not appear, click the **Eclipse Contributor Agreement** in the **Status** box to go to the agreement that you need to sign.
+4. Fill the form and click the **Accept** button.
 
-#### Before you raise an issue
+#### Associating your Eclipse profile with your GitHub ID
+1. From your Eclipse account, select **Edit Profile**.
+2. On the **Personal Information** tab, go to the **Social Media Links** section and add your GitHub user name to the **GitHub Username** field.
+3. Answer the **Have you changed employers** question.
+4. Enter your Eclipse password in the **Current password** field and then click **Save**.
+
+For more information about Codewind workflows, see the [Codewind GitHub Workflows wiki](https://wiki.eclipse.org/Codewind_GitHub_Workflows).
+
+#### Checking if your issue is already addressed
 - Search the [list of issues](https://github.com/eclipse/codewind/issues) to see if your issue has already been raised.
 - See the [Codewind documentation](https://www.eclipse.org/codewind/docindex.html) to see if existing documentation addresses your question or concern.
 


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

Adding info to the Contributing.md file about signing the ECA and associating your Eclipse profile with your GitHub ID.

Part of issue https://github.com/eclipse/codewind-docs/issues/30.