### PR TITLE
Server name of defaultServer is currently required

### DIFF
--- a/docs/_documentations/mdt-eclipse-importedprojects.md
+++ b/docs/_documentations/mdt-eclipse-importedprojects.md
@@ -71,6 +71,7 @@ Configure your `pom.xml` file as follows:
                   <version>2.1.1</version>
                   <extensions>true</extensions>
                   <configuration>
+                      <serverName>defaultServer</serverName>
                       <looseApplication>true</looseApplication>
                       <appsDirectory>apps</appsDirectory>
                       <installDirectory>/opt/ibm/wlp</installDirectory>

--- a/docs/_documentations/mdt-vsc-importedprojects.md
+++ b/docs/_documentations/mdt-vsc-importedprojects.md
@@ -71,6 +71,7 @@ Configure your `pom.xml` file as follows:
                   <version>2.1.1</version>
                   <extensions>true</extensions>
                   <configuration>
+                      <serverName>defaultServer</serverName>
                       <looseApplication>true</looseApplication>
                       <appsDirectory>apps</appsDirectory>
                       <installDirectory>/opt/ibm/wlp</installDirectory>


### PR DESCRIPTION
The server name is required to be `defaultServer` at the moment in order for Codewind to be able to start the server properly so I'm updating the import docs to reflect that.