### PR TITLE
Removing See Also sections

### DIFF
--- a/docs/_documentations/mdt-vsc-commands-project.md
+++ b/docs/_documentations/mdt-vsc-commands-project.md
@@ -12,12 +12,6 @@ parent: mdt-vsc-commands-overview
 
 # Project commands: Codewind for VS Code
 
-### **See also:**
-- [Commands overview](mdt-vsc-commands-overview.html)
-- [Restart and debug](mdt-vsc-commands-restart-and-debug.html)
-
-***
-
 ## Create a new project or work with an existing project
 
 - To create a new project, right-click the *Projects (Local)* item and select **Create New Project**, or click on the *+* icon beside the *Projects (Local)* item. You can also create a new project using the **Command Palette**.

--- a/docs/_documentations/mdt-vsc-commands-restart-and-debug.md
+++ b/docs/_documentations/mdt-vsc-commands-restart-and-debug.md
@@ -12,12 +12,6 @@ parent: mdt-vsc-commands-overview
 
 # Restart and debug: Codewind for VS Code
 
-### **See also:**
-- [Commands overview](mdt-vsc-commands-overview.html)
-- [Project commands](mdt-vsc-commands-project.html)
-
-***
-
 Restart and debug commands are available in the Command Palette and by right-clicking a project in the Codewind view.
 You must restart a project in **Debug** mode before you can debug that project.
 For a walkthrough of the debug functionality, see the [tutorial](mdt-vsc-tutorial.html).
@@ -37,6 +31,7 @@ Next, the launch configuration runs, and the VS Code debugger attaches to your a
 ## See also:
 - [VS Code debug documentation for Node.js](https://code.visualstudio.com/docs/nodejs/nodejs-debugging)
 - [VS Code debug documentation for Java](https://code.visualstudio.com/blogs/2017/09/28/java-debug)
+- [Project commands](mdt-vsc-commands-project.html)
 - [Debug troubleshooting](mdt-vsc-troubleshooting.html#debug)
 
 ***


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

Removing "See Also" sections based on feedback. Part of https://github.com/eclipse/codewind-docs/issues/53.