### PR TITLE
Moving news file to news folder

### DIFF
--- a/docs/_news/newstechpreview.md
+++ b/docs/_news/newstechpreview.md
@@ -1,0 +1,40 @@
+---
+layout: docs
+title: New for Codewind tech preview
+description: New for Codewind tech preview
+keywords: news, new, updates, update, techpreview
+duration: 1 minute
+permalink: newstechpreview
+---
+
+## May 2019
+
+In the tech preview, Codewind includes the following supported functions with the included extensions:
+- Create projects from templates, build, and deploy.
+- Bind to existing projects, build, and deploy.
+- View all projects, including application and build statuses.
+- Debug and incrementally update MicroProfile, Spring, and Node.js projects.
+- View application and build logs.
+- View an overview of project information.
+- Integrate validation errors into the IDE problem views.
+- Open a shell session into an application container.
+- Toggle project auto build and manually initiate project builds.
+- Disable, enable, and delete projects.
+- Launch performance metrics and load testing.
+
+This release includes the following limitations:
+- Only the local desktop using VS Code and Eclipse and deploying to Docker Desktop is supported.
+- The release does not include Che or hosted support.
+- Only macOS is supported.
+
+## June 2019
+- Simplified, single-step installation: install the IDE extension, and activation pulls the rest as required.
+- Desktop support for Windows and Linux is included.
+- Support for Eclipse Che running on OKD and RHOS is included.
+- Two new Codewind extensions are added:
+  - Appsody - Native IDE integration of Appsody for VS Code and Eclipse.
+  - OpenAPI - Scaffold an application quickly from an OpenAPI definition in VS Code or Eclipse.
+- Support for multiple template repositories to allow adding Kabanero and Appsody templates to the Codewind configuration is added.
+- A Kabanero version of Che is included.
+- A new performance dashboard is added.
+- Landing page updates include a docs section and a Codewind introduction video.


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

I am moving the newstechpreview file to its correct location in the _news folder.