### PR TITLE
Updates for ROKS

### DIFF
--- a/docs/_documentations/mdt-che-roks.md
+++ b/docs/_documentations/mdt-che-roks.md
@@ -55,6 +55,7 @@ type: document
 5. Export the folders in the `/etc/exports` directory:
    - First, retrieve the public IP addresses for your worker nodes.
    - Then, add the following code to the `/etc/exports` directory. Repeat for as many worker nodes that you have. Do not use the wildcard to whitelist all IP addresses.
+   
    ```
    /nfs/codewind/data worker1-public-ip(rw,sync,no_subtree_check,insecure,no_root_squash)
    /nfs/codewind/workspace1 worker1-public-ip(rw,sync,no_subtree_check,insecure,no_root_squash)
@@ -70,6 +71,7 @@ type: document
    /nfs/codewind/workspace4 worker2-public-ip(rw,sync,no_subtree_check,insecure,no_root_squash)
    /nfs/codewind/workspace5 worker2-public-ip(rw,sync,no_subtree_check,insecure,no_root_squash)
    ```
+   
 6. Restart the NFS server:
 ```
 systemctl restart nfs-kernel-server

--- a/docs/_news/news04.md
+++ b/docs/_news/news04.md
@@ -16,7 +16,7 @@ Friday 20 September 2019
 - The Appsody init is no longer called in the Docker container. Instead, the Appsody binary is installed as part of the IDE. With this update, a Docker bind is no longer needed for Appsody creation.
 
 #### Che
-- Red Hat OpenShift Kubernetes Service (ROKS) on IBM Cloud support is available.
+- Red Hat OpenShift on IBM Cloud (ROKS) support is available.
 
 #### Eclipse
 - [IDE support is available for configuring template sources.](https://github.com/eclipse/codewind/issues/32)

--- a/docs/_news/news04.md
+++ b/docs/_news/news04.md
@@ -16,7 +16,7 @@ Friday 20 September 2019
 - The Appsody init is no longer called in the Docker container. Instead, the Appsody binary is installed as part of the IDE. With this update, a Docker bind is no longer needed for Appsody creation.
 
 #### Che
-- Red Hat OpenStack (RHOS) IBM Cloud Kubernetes Service (IKS) support is available.
+- Red Hat OpenShift Kubernetes Service (ROKS) on IBM Cloud support is available.
 
 #### Eclipse
 - [IDE support is available for configuring template sources.](https://github.com/eclipse/codewind/issues/32)


### PR DESCRIPTION
- Updates the news section for ROKS to clarify that it's `Red Hat OpenShift Kubernetes Service` not `Red Hat OpenStack on IBM Cloud`
- FIxes formatting in the ROKS doc