### PR TITLE
Make getting start link also a parent

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -19,7 +19,7 @@
 				{% assign hash = '#' | append: entry.title | downcase | replace: " ", "_" %}
 			    {% assign anchor = entry.title | downcase | replace: " ", "_" %}
 				    
-		        <a href="{{ hash }}" data-toggle="collapse" aria-expanded="false" class="bg-light list-group-item list-group-item-action flex-column align-items-start collapsed">
+		        <a href="{{ hash }}" data-url="{{entry.url}}" data-toggle="collapse" aria-expanded="false" class="bg-light list-group-item list-group-item-action flex-column align-items-start collapsed">
 		                <div class="d-flex w-100 justify-content-start align-items-center">
 		                    <span class="menu-collapsed">{{ entry.title }}</span>
 		                    <span class="submenu-icon"></span>

--- a/docs/js/docs.js
+++ b/docs/js/docs.js
@@ -7,21 +7,27 @@ $(function() {
         });
     });
     
+    var location = window.location;
+    var pathname = location.pathname.substring(location.pathname.lastIndexOf('/') + 1);
+
     
-    $('a[href^="#"]').not('.list-group-item').on("click", function(e) {
-    	
-    		e.preventDefault();
-    		var id = $($(this).attr('href'));
-       
-        if (id.length === 0) {
-            return;
+    var clicked = false;
+    $(':not(a[data-url=""])').each ( function() {
+        
+        if ($(this).data('url') == pathname) {
+        		clicked = true;
+            $(this).trigger("click");
         }
         
-        var pos = id.offset().top - 131;
+    });
+    
+    $(':not(a[data-url=""])').on("click", function(e) {
 
-        // animated top scrolling
-        $('body, html').animate({scrollTop: pos});
-    });  
+		if ($(this).data("url") && !clicked) {
+			window.location.replace($(this).data("url"));
+		}
+	});
+
     
     
 });


### PR DESCRIPTION
this PR is for https://github.com/eclipse/codewind/issues/591

In current landing page, if the toc link is a parent, then it cannot be a page.  With this PR, the link can be a page. 

To test out, modify this file 

`_data/docstoc.yml` to something like this:

```
- title: 'Getting started'
  url: gettingstarted.html
  children:
    - title: 'Overview'
      url: mdteclipseoverview.html
- title: 'Developing with Codewind'
  children:
```


Signed-off-by: tiaoyuw <tiaoyuw@ca.ibm.com>