### PR TITLE
[WIP not reqd for 0.6.0] Draft new topic for local and remote

### DIFF
--- a/docs/_documentations/gettingstartedoptions.md
+++ b/docs/_documentations/gettingstartedoptions.md
@@ -9,7 +9,7 @@ permalink: gettingstartedoptions
 
 # Which Getting Started option should I choose? 
 
-Codewind helps you to develop, build, and deploy your app wherever you want. You can choose to edit, build, and run your app locally, or in the Cloud.
+Codewind helps you to develop, build, and deploy your apps wherever you want. You can choose to edit, build, and run your apps locally, or in the Cloud.
 
 ## Local
 

--- a/docs/_documentations/gettingstartedoptions.md
+++ b/docs/_documentations/gettingstartedoptions.md
@@ -1,0 +1,39 @@
+---
+layout: docs
+title: About the options
+description: Getting start options
+keywords: install, standalone, cloud
+duration: 1 minute
+permalink: gettingstartedoptions
+---
+
+# Which Getting Started option should I choose? 
+
+Codewind helps you to develop your app wherever you want by supporting three primary development scenarios:
+1. Locally in VS Code or Eclipse.
+2. Remotely in the Cloud using Eclipse Che.
+3. Hybrid, which uses a combination of both local and remote development. 
+
+In all three scenarios, Codewind helps you by doing all the hard work of building your apps into high quality deployable applications in containers. You can then deploy these containers anywhere into a Kubernetes environment. 
+
+## Local development
+
+Local development is where you install and use Codewind on your machine in your preferred IDE. When you install Codewind locally, it downloads everything it needs and you can then use it to help you develop your applications. 
+
+Codewind detects changes to your code and automatically rebuilds it. Your code is compiled together with any dependencies into readily deployable containers that are located locally on your machine. 
+
+## Remote development
+
+Remote development is where you install and use Codewind in the Cloud in Eclipse Che. You can use this option to help you to develop your applications wholly off premises.
+
+You install Eclipse Che in the Cloud, install Codewind in the Cloud, create the Codewind workspace, and then edit your applications in the Cloud.
+
+Codewind detects changes to your code and automatically rebuilds it. Your code is compiled together with any dependencies into readily deployable containers that are located in the Cloud. 
+
+## Hybrid development
+
+Hybrid is a combination of both local and remote development. Use this option to host your code locally and build and deploy your applications in the Cloud. 
+
+You install Codewind locally in your preferred IDE, install Codewind in the Cloud, and then create a Codewind workspace. You then edit your applications locally. 
+
+Codewind detects changes to your code and automatically rebuilds it. Your code is compiled together with any dependencies into readily deployable containers that are located in the Cloud. 

--- a/docs/_documentations/gettingstartedoptions.md
+++ b/docs/_documentations/gettingstartedoptions.md
@@ -1,39 +1,20 @@
 ---
 layout: docs
 title: About the options
-description: Getting start options
-keywords: install, standalone, cloud
+description: About the options
+keywords: install, standalone, cloud, local, development
 duration: 1 minute
 permalink: gettingstartedoptions
 ---
 
 # Which Getting Started option should I choose? 
 
-Codewind helps you to develop your app wherever you want by supporting three primary development scenarios:
-1. Locally in VS Code or Eclipse.
-2. Remotely in the Cloud using Eclipse Che.
-3. Hybrid, which uses a combination of both local and remote development. 
+Codewind helps you to develop, build, and deploy your app wherever you want. You can choose to edit, build, and run your app locally, or in the Cloud.
 
-In all three scenarios, Codewind helps you by doing all the hard work of building your apps into high quality deployable applications in containers. You can then deploy these containers anywhere into a Kubernetes environment. 
+## Local
 
-## Local development
+If you want to develop your apps locally, choose a local option. You can use your favourite IDE on your machine to develop your apps, and Codewind can build and run these locally for you. 
 
-Local development is where you install and use Codewind on your machine in your preferred IDE. When you install Codewind locally, it downloads everything it needs and you can then use it to help you develop your applications. 
+## Cloud
 
-Codewind detects changes to your code and automatically rebuilds it. Your code is compiled together with any dependencies into readily deployable containers that are located locally on your machine. 
-
-## Remote development
-
-Remote development is where you install and use Codewind in the Cloud in Eclipse Che. You can use this option to help you to develop your applications wholly off premises.
-
-You install Eclipse Che in the Cloud, install Codewind in the Cloud, create the Codewind workspace, and then edit your applications in the Cloud.
-
-Codewind detects changes to your code and automatically rebuilds it. Your code is compiled together with any dependencies into readily deployable containers that are located in the Cloud. 
-
-## Hybrid development
-
-Hybrid is a combination of both local and remote development. Use this option to host your code locally and build and deploy your applications in the Cloud. 
-
-You install Codewind locally in your preferred IDE, install Codewind in the Cloud, and then create a Codewind workspace. You then edit your applications locally. 
-
-Codewind detects changes to your code and automatically rebuilds it. Your code is compiled together with any dependencies into readily deployable containers that are located in the Cloud. 
+If you prefer to develop your apps in the Cloud, choose the Cloud option. You can use the Cloud-based IDE of your choice, and you can develop your apps and build and deploy these fully in any Cloud. 


### PR DESCRIPTION
Signed-off-by: micgibso <micgibso@uk.ibm.com>

Add new gettingstartedoptions.md topic under **Getting started** in the toc explaining the three primary development options of local,  remote, and hybrid. The topic will be positioned in the toc thus:
![image](https://user-images.githubusercontent.com/7224752/66028831-d39e5400-e4f5-11e9-8141-f174d7aed9f8.png)

This is intended to help users new to Codewind to decide which startup option suits them best. 

In testing, found that you cannot navigate back to the **Getting started** topic unless you click the Back button, so opened https://github.com/eclipse/codewind/issues/591 in discussion with Travis. 

@tobespc @hhellyer Could you review please? Ta. 