### PR TITLE
Updates for Che/Codewind on Kube

### DIFF
--- a/docs/_documentations/installoncloud.md
+++ b/docs/_documentations/installoncloud.md
@@ -40,7 +40,7 @@ Complete the following steps after you install `chectl`:
 
 1. Download the [codewind-che checluster yaml](https://github.com/eclipse/codewind-che-plugin/blob/master/setup/install_che/che-operator/codewind-checluster.yaml) file to your machine.
     - You can modify this file, but leave the `spec.server.cheWorkspaceClusterRole` field set to `eclipse-codewind` and the `spec.storage.preCreateSubPaths` field set to `true`.
-2. If you install on Kubernetes, determine your Ingress domain. If you're unsure of your Ingress domain, ask your cluster administrator.
+2. If you're installing on a Kubernetes platform other than OpenShift, determine your Ingress domain. If you're unsure of your Ingress domain, ask your cluster administrator.
     - Set the `spec.server.ingressDomain` field in the Che .yaml to the Ingress domain.
 2. Install Che:
     - On OpenShift 3.x run the following command: `chectl server:start --platform=openshift --installer=operator --che-operator-cr-yaml=<codewind-che.yaml file>`

--- a/docs/_documentations/installoncloud.md
+++ b/docs/_documentations/installoncloud.md
@@ -42,7 +42,7 @@ Complete the following steps after you install `chectl`:
     - You can modify this file, but leave the `spec.server.cheWorkspaceClusterRole` field set to `eclipse-codewind` and the `spec.storage.preCreateSubPaths` field set to `true`.
 2. If you're installing on a Kubernetes platform other than OpenShift, determine your Ingress domain. If you're unsure of your Ingress domain, ask your cluster administrator.
     - Set the `spec.server.ingressDomain` field in the Che .yaml to the Ingress domain.
-2. Install Che:
+3. Install Che:
     - On OpenShift 3.x run the following command: `chectl server:start --platform=openshift --installer=operator --che-operator-cr-yaml=<codewind-che.yaml file>`
     - On Kubernetes run the following command: `chectl server:start --platform=k8s --installer=operator --domain=<ingress-domain> --che-operator-cr-yaml=<codewind-che.yaml file>`
 

--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -74,18 +74,6 @@ When using OS authentication setups (for example, AzureAD), Docker Shared Drive 
 2. Create the new account with the same username but without the prefix (for example, if your AzureAD account is `AzureAD/BobSmith`, your new local account should be `BobSmith`). Use the same password as your other account.
 3. Select your new local account and click **Change account type**. Select the dropdown menu and select **Administrator**. Share the drive again in Docker.
 
-<!--
-Action/Topic : Installing Codewind
-Issue type: bug/info
-Issue link:
-18.10:
--->
-## Unable to create multiple Codewind workspaces on Docker Desktop Kubernetes
-When running a Docker Desktop local Kubernetes cluster, multiple Codewind workspaces may fail to start.
-
-**Workaround:**
-Use only one Codewind Che workspace on Docker Desktop for the time being, or use an alternative local Kubernetes cluster such as Minikube or Minishift. Due to how Docker Desktop handles networking, multiple Codewind workspaces may cause a collision on the port that it's running on.
-
 ***
 # Creating a project
 


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

- Updates step 2 in the Che install docs to be a little more clear (OpenShift is a Kube platform too)
- Removes a now outdated troubleshooting doc from our 0.2.0 release.