### PR TITLE
added binding appsody projects

### DIFF
--- a/docs/_documentations/mdt-eclipse-importedprojects.md
+++ b/docs/_documentations/mdt-eclipse-importedprojects.md
@@ -12,7 +12,7 @@ order: 0
 
 # Adding existing projects
 
-Modifications are usually required to successfully add and deploy projects that have never been run in Codewind before. <!--The add process creates required files if they do not exist.--> This guide covers the basics of configuring a project to run in Codewind.
+Modifications are usually required to successfully add and deploy projects that have never been run in Codewind before. This guide covers the basics of configuring a project to run in Codewind.
 
 ## What kind of projects can I add?
 
@@ -23,7 +23,7 @@ Codewind is designed to develop cloud native microservices. Therefore, each proj
 * [Node.js projects](#nodejs-projects)
 * [Swift projects](#swift-projects)
 * [Generic Docker projects](#generic-docker-projects)
-* [Binding Appsody projects](#binding-appsody-projects) 
+* [Appsody projects](#binding-appsody-projects) 
 
 ### Binding Appsody projects
 

--- a/docs/_documentations/mdt-eclipse-importedprojects.md
+++ b/docs/_documentations/mdt-eclipse-importedprojects.md
@@ -23,10 +23,11 @@ Codewind is designed to develop cloud native microservices. Therefore, each proj
 * [Node.js projects](#nodejs-projects)
 * [Swift projects](#swift-projects)
 * [Generic Docker projects](#generic-docker-projects)
+* [Binding Appsody projects](#binding-appsody-projects) 
 
 ### Binding Appsody projects
 
-If you have existing Appsody project, or a project that you wish to add to Codewind as an Appsody project, select the corresponding Appsody project type and, if applicable, the Appsody stack when adding the project. 
+If you have an existing Appsody project, or a project that you wish to add to Codewind as an Appsody project, select the corresponding Appsody project type and, if applicable, the Appsody stack when adding the project. 
 For more information on Appsody and Appsody stacks, visit https://appsody.dev 
 
 ## MicroProfile/Java EE projects

--- a/docs/_documentations/mdt-eclipse-importedprojects.md
+++ b/docs/_documentations/mdt-eclipse-importedprojects.md
@@ -24,6 +24,11 @@ Codewind is designed to develop cloud native microservices. Therefore, each proj
 * [Swift projects](#swift-projects)
 * [Generic Docker projects](#generic-docker-projects)
 
+### Binding Appsody projects
+
+If you have existing Appsody project, or a project that you wish to add to Codewind as an Appsody project, select the corresponding Appsody project type and, if applicable, the Appsody stack when adding the project. 
+For more information on Appsody and Appsody stacks, visit https://appsody.dev 
+
 ## MicroProfile/Java EE projects
 
 MicroProfile projects are Java applications that are deployed to WebSphere Liberty. They are built by using Maven and the `liberty-maven-plugin` and are based on the [WebSphere Liberty Docker image](https://hub.docker.com/_/websphere-liberty/). MicroProfile projects support rapid iterative development in Codewind with a few changes to your `pom.xml` file.

--- a/docs/_documentations/mdt-vsc-importedprojects.md
+++ b/docs/_documentations/mdt-vsc-importedprojects.md
@@ -12,7 +12,7 @@ order: 0
 
 # Adding existing projects
 
-Modifications are usually required to successfully add and deploy projects that have never been run in Codewind before. <!--The add process creates required files if they do not exist.--> This guide covers the basics of configuring a project to run in Codewind.
+Modifications are usually required to successfully add and deploy projects that have never been run in Codewind before. This guide covers the basics of configuring a project to run in Codewind.
 
 ## What kind of projects can I add?
 
@@ -23,7 +23,7 @@ Codewind is designed to develop cloud native microservices. Therefore, each proj
 * [Node.js projects](#nodejs-projects)
 * [Swift projects](#swift-projects)
 * [Generic Docker projects](#generic-docker-projects)
-* [Binding Appsody projects](#binding-appsody-projects) 
+* [Appsody projects](#binding-appsody-projects) 
 
 ### Binding Appsody projects
 

--- a/docs/_documentations/mdt-vsc-importedprojects.md
+++ b/docs/_documentations/mdt-vsc-importedprojects.md
@@ -23,10 +23,11 @@ Codewind is designed to develop cloud native microservices. Therefore, each proj
 * [Node.js projects](#nodejs-projects)
 * [Swift projects](#swift-projects)
 * [Generic Docker projects](#generic-docker-projects)
+* [Binding Appsody projects](#binding-appsody-projects) 
 
 ### Binding Appsody projects
 
-If you have existing Appsody project, or a project that you wish to add to Codewind as an Appsody project, select the corresponding Appsody project type and, if applicable, the Appsody stack when adding the project. 
+If you have an existing Appsody project, or a project that you wish to add to Codewind as an Appsody project, select the corresponding Appsody project type and, if applicable, the Appsody stack when adding the project. 
 For more information on Appsody and Appsody stacks, visit https://appsody.dev 
 
 ## MicroProfile/Java EE projects

--- a/docs/_documentations/mdt-vsc-importedprojects.md
+++ b/docs/_documentations/mdt-vsc-importedprojects.md
@@ -24,6 +24,11 @@ Codewind is designed to develop cloud native microservices. Therefore, each proj
 * [Swift projects](#swift-projects)
 * [Generic Docker projects](#generic-docker-projects)
 
+### Binding Appsody projects
+
+If you have existing Appsody project, or a project that you wish to add to Codewind as an Appsody project, select the corresponding Appsody project type and, if applicable, the Appsody stack when adding the project. 
+For more information on Appsody and Appsody stacks, visit https://appsody.dev 
+
 ## MicroProfile/Java EE projects
 
 MicroProfile projects are Java applications that are deployed to WebSphere Liberty. They are built by using Maven and the `liberty-maven-plugin` and are based on the [WebSphere Liberty Docker image](https://hub.docker.com/_/websphere-liberty/). MicroProfile projects support rapid iterative development in Codewind with a few changes to your `pom.xml` file.


### PR DESCRIPTION
Signed-off-by: Jacob Berger <jacob.berger@ibm.com>

In response to issue 292, `support binding existing project to appsody` from eclipse/codewind: https://github.com/eclipse/codewind/issues/292

I added a section, `Binding Appsody projects.`  