### PR TITLE
Updating link, commands

### DIFF
--- a/docs/_documentations/installoncloud.md
+++ b/docs/_documentations/installoncloud.md
@@ -20,16 +20,15 @@ The Eclipse tools are [open source](https://github.com/eclipse/codewind-eclipse)
 
 To get started, see [Getting started with Codewind](mdteclipsegettingstarted.html).
 
-To uninstall Codewind, see [Uninstalling Codewind for Eclipse](mdteclipseuninstall.html)
+To uninstall Codewind, see [Uninstalling Codewind for Eclipse](mdteclipseuninstall.html).
 
-## Codewind OpenShift (ODO) extension 
-Extension to Codewind providing support for ODO projects: https://codewind.dev
+## Codewind OpenShift (odo) extension 
+See the [`codewind-odo-extension` repository](https://github.com/eclipse/codewind-odo-extension) for the extension to Codewind providing support for odo projects.
 
-### Add additional rules to support Codewind ODO extension
-The ODO extension needs to add additional rules for accessing OpenShift resources:
-1. In your home directory, run the following command to clone the ODO extension repository:
-`git clone https://github.com/eclipse/codewind-odo-extension`
-2. Login to your OpenShift/OKD cluster
-3. Go into `~/codewind-odo-extension/odo-RBAC` then run the following commands to add additional rules:
-`kubectl apply -f codewind-odoclusterrole.yaml`
-`kubectl apply -f codewind-odoclusterrolebinding.yaml`
+### Add additional rules to support the Codewind odo extension
+The odo extension needs additional rules for accessing OpenShift resources. Use the following commands to clone the `codewind-che-plugin` repository, create the ClusterRole with the required permissions, and bind that ClusterRole to the Che workspace service account:
+```
+git clone https://github.com/eclipse/codewind-che-plugin.git && \
+    kubectl apply -f codewind-che-plugin/setup/install_che/codewind-clusterrole.yaml && \
+    kubectl apply -f codewind-che-plugin/setup/install_che/codewind-rolebinding.yaml
+```


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

I have updated the commands into a code block as recommended in https://github.com/eclipse/codewind/issues/708.

Also, I noticed the link on line 26 just took us to the website, which didn't seem very specific. I changed the link to point to https://github.com/eclipse/codewind-odo-extension instead.
