### PR TITLE
Corrections to news date, TOC titles

### DIFF
--- a/docs/_data/newstoc.yml
+++ b/docs/_data/newstoc.yml
@@ -1,10 +1,10 @@
-- title: 'Codewind 0.50'
+- title: 'Codewind 0.5.0'
   url: news05.html
 
-- title: 'Codewind 0.40'
+- title: 'Codewind 0.4.0'
   url: news04.html
 
-- title: 'Codewind 0.30'
+- title: 'Codewind 0.3.0'
   url: news03.html
 
 - title: 'Codewind tech preview'

--- a/docs/_news/news05.md
+++ b/docs/_news/news05.md
@@ -8,7 +8,7 @@ permalink: news05
 ---
 
 ## Codewind 0.5.0
-Thursday 17 October 2019
+Thursday 24 October 2019
 
 #### Appsody
 - You can now easily import existing Appsody projects into Codewind, or convert projects to use Appsody during import. If you are using the Eclipse IDE, see [Adding existing projects](mdteclipseimportedprojects.html). If you are using VS Code, see [Adding existing projects](mdt-vsc-importedprojects.html).


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

I am correcting the 0.5.0 news date and all the 0.x.0 TOC headings for issue https://github.com/eclipse/codewind/issues/852.