### PR TITLE
fixed news link

### DIFF
--- a/docs/_includes/topbar.html
+++ b/docs/_includes/topbar.html
@@ -13,7 +13,7 @@
                     <a class="nav-link cw-nav-link cw-header-link-text" href="gettingstarted.html">Docs</a>
                 </li>
                 <li class="nav-item cw-navbar-item cw-header-link-news">
-                    <a class="nav-link cw-nav-link cw-header-link-text" href="news05.html">News</a>
+                    <a class="nav-link cw-nav-link cw-header-link-text" href="news.html">News</a>
                 </li>
                 
                 <li class="nav-item cw-navbar-item cw-header-link">

--- a/docs/_layouts/newsredirect.html
+++ b/docs/_layouts/newsredirect.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+{% assign entry = site.data.newstoc | first %}
+  <head>
+    <meta http-equiv="Refresh" content="0; url={{entry.url}}" />
+  </head>
+</html>

--- a/docs/_news/news.md
+++ b/docs/_news/news.md
@@ -1,0 +1,5 @@
+---
+layout: newsredirect
+description: This is for redirect to latest news only, do not delete/edit
+permalink: news
+---


### PR DESCRIPTION
Fixes: https://github.com/eclipse/codewind/issues/871

Now news.html will always redirect to latest news page.

Signed-off-by: tiaoyuw <tiaoyuw@ca.ibm.com>