### PR TITLE
Adding Appsody and alphabetizing list

### DIFF
--- a/docs/_documentations/mdt-che-overview.md
+++ b/docs/_documentations/mdt-che-overview.md
@@ -14,7 +14,7 @@ parent: settingownide
 
 You can use [Codewind for Eclipse Che](https://marketplace.eclipse.org/content/codewind) to develop and debug your containerized projects from within Eclipse.
 
-Use the Eclipse IDE to create and make modifications to your application, see the application and build status, view the logs, and run your application.  Codewind for Eclipse supports development of Microprofile/Java EE, Java Lagom, Spring, Node.js, Go, Python and Swift containerized projects. In addition, Microprofile/Java EE, Spring, and Node.js applications can be debugged.
+Use the Eclipse IDE to create and make modifications to your application, see the application and build status, view the logs, and run your application. Codewind for Eclipse supports development of Appsody, Go, Java Lagom, Microprofile/Java EE, Node.js, Python, Spring, and Swift containerized projects. In addition, Microprofile/Java EE, Spring, and Node.js applications can be debugged.
 
 The Eclipse tools are [open source](https://github.com/eclipse/codewind-eclipse). You are encouraged to browse the code, open issues, and contribute.
 

--- a/docs/_documentations/mdt-eclipse-overview.md
+++ b/docs/_documentations/mdt-eclipse-overview.md
@@ -14,7 +14,7 @@ parent: settingownide
 
 You can use [Codewind for Eclipse](https://marketplace.eclipse.org/content/codewind) to develop and debug your containerized projects from within Eclipse.
 
-Use the Eclipse IDE to create and make modifications to your application, see the application and build status, view the logs, and run your application.  Codewind for Eclipse supports development of Microprofile/Java EE, Java Lagom, Spring, Node.js, Go, Python, Swift, and Appsody containerized projects. In addition, Microprofile/Java EE, Spring, and Node.js applications can be debugged.
+Use the Eclipse IDE to create and make modifications to your application, see the application and build status, view the logs, and run your application. Codewind for Eclipse supports development of Appsody, Go, Java Lagom, Microprofile/Java EE, Node.js, Python, Spring, and Swift containerized projects. In addition, Microprofile/Java EE, Spring, and Node.js applications can be debugged.
 
 The Eclipse tools are [open source](https://github.com/eclipse/codewind-eclipse). You are encouraged to browse the code, open issues, and contribute.
 

--- a/docs/_documentations/mdt-vsc-overview.md
+++ b/docs/_documentations/mdt-vsc-overview.md
@@ -14,7 +14,7 @@ parent: settingownide
 
 You can use [Codewind for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=IBM.codewind) to develop and debug your containerized projects from within VS Code.
 
-Write code, track application and build statuses, view project logs, and run your application. Codewind for VS Code supports development of Microprofile/Java EE, Java Lagom, Spring, Node.js, Go, Python, Swift, and Appsody containerized projects. In addition, the tools support easily debugging Microprofile/Java EE, Spring, and Node.js applications.
+Write code, track application and build statuses, view project logs, and run your application. Codewind for VS Code supports development of Appsody, Go, Java Lagom, Microprofile/Java EE, Node.js, Python, Spring, and Swift containerized projects. In addition, the tools support easily debugging Microprofile/Java EE, Spring, and Node.js applications.
 
 The VS Code tools are [open source](https://github.com/eclipse/codewind-vscode). You can browse the code, open issues, and contribute.
 


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

Two changes:
1️⃣ Added Appsody to the `mdt-che-overview` file.
2️⃣ Reorganized list of containerized projects in all three overview files so that the names appear in alphabetical order.