### PR TITLE
Adding section for failing Appsody binds

### DIFF
--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -398,15 +398,13 @@ Issue link: https://github.com/eclipse/codewind/issues/1061
 -->
 ## Appsody binds fail
 
-If an Appsody respository is already added in your local Appsody CLI, and if you try to add the Appsody repository again with a different name or ID, the Appsody bind might fail in the following scenario:
-1. Use a template manager to add the Appsody repository in Codewind.
-2. Try to bind the project to a stack from the added Appsody repository.
-3. Create the project in Codewind.
-The `appsody.log` displays this error:
+If an Appsody respository is already added in your local Appsody CLI, the Appsody bind might fail in the following scenario:
+1. Use the template manager to add the Appsody repository in Codewind.
+2. Try to bind the project to a stack from the added Appsody repository. The project appears in the Codewind Explorer view, and the `appsody.log` displays this error:
 ```
 [Error] The current directory is not a valid appsody project. Run `appsody init <stack>` to create one. Run `appsody list` to see the available stacks.
 ```
-The `cwctl` log path in the Codewind log in VS Code displays an error like this one:
+In the Codewind log in VS Code, the `cwctl` log displays an error like this one:
 ```
 2019/11/08 11:07:29 Please wait while the command runs... 
 2019/11/08 11:07:31 [Error] Repository 77b94c9b-0daf-5426-98b8-83eb8ee63e3c is not in configured list of repositories

--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -398,8 +398,10 @@ Issue link: https://github.com/eclipse/codewind/issues/1061
 -->
 ## Appsody binds fail
 
-The Appsody bind might fail if the following events occurred:
-1. The Appsody repository was added to your local Appsody CLI from your IDE by right-clicking **Projects (Local)** and then clicking **Manage Template Sources**.
+If an Appsody repository is already added in your local Appsody CLI, the Appsody bind might fail.
+
+These steps create the issue:
+1. The Appsody repository was added to your local Appsody CLI from your IDE by right-clicking **Projects (Local)** and then clicking **Manage Template Sources**. The same Appsody repository was then added to Codewind from your IDE.
 2. Later, a project was bound to a stack from the added Appsody repository. The project appears in the Codewind Explorer view, and the `appsody.log` displays this error:
 ```
 [Error] The current directory is not a valid appsody project. Run `appsody init <stack>` to create one. Run `appsody list` to see the available stacks.

--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -390,6 +390,33 @@ These steps reproduce the issue:
 
 **Workaround** Run the `Attach Debugger` action manually.
 
+<!--
+Codewind version: 0.6.0
+Action/Topic: Appsody with Codewind
+Issue type: bug/info
+Issue link: https://github.com/eclipse/codewind/issues/1061
+-->
+## Appsody binds fail
+
+If an Appsody respository is already added in your local Appsody CLI, and if you try to add the Appsody repository again with a different name or ID, the Appsody bind might fail in the following scenario:
+1. Use a template manager to add the Appsody repository in Codewind.
+2. Try to bind the project to a stack from the added Appsody repository.
+3. Create the project in Codewind.
+The `appsody.log` displays this error:
+```
+[Error] The current directory is not a valid appsody project. Run `appsody init <stack>` to create one. Run `appsody list` to see the available stacks.
+```
+The `cwctl` log path in the Codewind log in VS Code displays an error like this one:
+```
+2019/11/08 11:07:29 Please wait while the command runs... 
+2019/11/08 11:07:31 [Error] Repository 77b94c9b-0daf-5426-98b8-83eb8ee63e3c is not in configured list of repositories
+```
+
+**Workaround**
+1. Remove the repository from the local Appsody CLI. For example, run the `appsody repo remove` command.
+2. Remove and add the repository back into Codewind with the template manager.
+3. Rebind the project to Codewind.
+
 ***
 # ODO with Codewind
 

--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -401,7 +401,7 @@ Issue link: https://github.com/eclipse/codewind/issues/1061
 If an Appsody repository is already added in your local Appsody CLI, the Appsody bind might fail.
 
 These steps create the issue:
-1. The Appsody repository was added to your local Appsody CLI from your IDE by right-clicking **Projects (Local)** and then clicking **Manage Template Sources**. The same Appsody repository was then added to Codewind from your IDE.
+1. The Appsody repository was added to your local Appsody CLI. The same Appsody repository was then added to Codewind from your IDE by right-clicking **Projects (Local)** and then clicking **Manage Template Sources**.
 2. Later, a project was bound to a stack from the added Appsody repository. The project appears in the Codewind Explorer view, and the `appsody.log` displays this error:
 ```
 [Error] The current directory is not a valid appsody project. Run `appsody init <stack>` to create one. Run `appsody list` to see the available stacks.

--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -398,9 +398,9 @@ Issue link: https://github.com/eclipse/codewind/issues/1061
 -->
 ## Appsody binds fail
 
-If an Appsody repository is already added in your local Appsody CLI, the Appsody bind might fail in the following scenario:
-1. From your IDE, right-click **Projects (Local)** and click **Manage Template Sources** to add the Appsody repository in Codewind.
-2. Try to bind the project to a stack from the added Appsody repository. The project appears in the Codewind Explorer view, and the `appsody.log` displays this error:
+The Appsody bind might fail if the following events occurred:
+1. The Appsody repository was added to your local Appsody CLI from your IDE by right-clicking **Projects (Local)** and then clicking **Manage Template Sources**.
+2. Later, a project was bound to a stack from the added Appsody repository. The project appears in the Codewind Explorer view, and the `appsody.log` displays this error:
 ```
 [Error] The current directory is not a valid appsody project. Run `appsody init <stack>` to create one. Run `appsody list` to see the available stacks.
 ```

--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -398,13 +398,13 @@ Issue link: https://github.com/eclipse/codewind/issues/1061
 -->
 ## Appsody binds fail
 
-If an Appsody respository is already added in your local Appsody CLI, the Appsody bind might fail in the following scenario:
-1. Use the template manager to add the Appsody repository in Codewind.
+If an Appsody repository is already added in your local Appsody CLI, the Appsody bind might fail in the following scenario:
+1. From your IDE, right-click **Projects (Local)** and click **Manage Template Sources** to add the Appsody repository in Codewind.
 2. Try to bind the project to a stack from the added Appsody repository. The project appears in the Codewind Explorer view, and the `appsody.log` displays this error:
 ```
 [Error] The current directory is not a valid appsody project. Run `appsody init <stack>` to create one. Run `appsody list` to see the available stacks.
 ```
-In the Codewind log in VS Code, the `cwctl` log displays an error like this one:
+Codewind displays an error. In VS Code, the error appears in the Codewind log:
 ```
 2019/11/08 11:07:29 Please wait while the command runs... 
 2019/11/08 11:07:31 [Error] Repository 77b94c9b-0daf-5426-98b8-83eb8ee63e3c is not in configured list of repositories
@@ -412,7 +412,7 @@ In the Codewind log in VS Code, the `cwctl` log displays an error like this one:
 
 **Workaround**
 1. Remove the repository from the local Appsody CLI. For example, run the `appsody repo remove` command.
-2. Remove and add the repository back into Codewind with the template manager.
+2. Remove and add the repository back into Codewind with **Manage Template Sources**.
 3. Rebind the project to Codewind.
 
 ***


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

PR for issue https://github.com/eclipse/codewind/issues/1061

Adding new troubleshooting section.