### PR TITLE
Minor change to node.js and swift templates remain in starting state

### DIFF
--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -326,7 +326,7 @@ Issue type: bug/info
 Issue link: https://github.com/eclipse/codewind-docs/issues/64
 18.10:
 -->
-## Node.js and Swift templates go from the starting state and then to the stopped state by default
+## Node.js and Swift templates remain in the starting state
 The templates `Appsody Node.js template` and `Appsody Swift template` go from the starting state to the stopped state by default. The application stops, but the container still runs. These templates do not have a server and are intended to help you implement your own server.
 
 **Workaround** To get the application into a started state, use a server for the application. After the application has a server, Codewind can monitor the server, and the status turns to `started` if the server is running.

--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -327,7 +327,7 @@ Issue link: https://github.com/eclipse/codewind-docs/issues/64
 18.10:
 -->
 ## Node.js and Swift templates remain in the starting state
-The templates `Appsody Node.js template` and `Appsody Swift template` go from the starting state to the stopped state by default. The application stops, but the container still runs. These templates do not have a server and are intended to help you implement your own server.
+The templates `Appsody Node.js template` and `Appsody Swift template` remain in the starting state by default because these templates do not have a server implemented, and therefore, its status cannot be detected. These templates do not have a server and are intended to help you implement your own server.
 
 **Workaround** To get the application into a started state, use a server for the application. After the application has a server, Codewind can monitor the server, and the status turns to `started` if the server is running.
 


### PR DESCRIPTION
Signed-off-by: Jacob Berger <jacob.berger@ibm.com>

For issue 1256: https://github.com/eclipse/codewind/issues/1256