### PR TITLE
Removing obsolete info from troubleshooting page

### DIFF
--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -605,7 +605,7 @@ The build is successful even though the validator reports this issue.
         ...
 ```
 
-The following workaround applies to Eclipse. The Spring server generator creates invalid source in the `OpenAPI2SpringBoot` class. Simply implement the methods from the interface and save the file. Also add the configuration element to the `pom.xml` file:
+The following workaround applies to Eclipse. Add the configuration element to the `pom.xml` file:
 
 ```xml
 <build>


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

PR for documentation for issue https://github.com/eclipse/codewind/issues/1116

See the last bullet point in the first comment.