### PR TITLE
Add separate odo extension documentation

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -56,6 +56,8 @@
           url: mdt-che-overview.html
         - title: 'Installing Codewind for Eclipse Che'
           url: 'mdt-che-installinfo.html'
+        - title: 'OpenShift Do (odo) support in Codewind'
+          url: 'mdt-che-odo-support.html'          
         - title: 'Docker Registry Guidance'
           url: dockerregistry.html
         - title: 'Using the OpenShift Registry'

--- a/docs/_documentations/mdt-che-installinfo.md
+++ b/docs/_documentations/mdt-che-installinfo.md
@@ -19,7 +19,7 @@ Installing Codewind for Eclipse Che comprises the following steps:
 4. [After installing Che](#after-installing-che)
 5. [Creating the Codewind workspace](#creating-the-codewind-workspace)
 6. [Updating the version](#updating-the-version)
-7. [Adding rules to support the Codewind odo extension](#adding-rules-to-support-the-codewind-odo-extension)
+7. [Adding extension to support OpenShift Do (odo)](https://www.eclipse.org/codewind/mdt-che-odo-support.html)
 
 ## Prerequisites
 1. Ensure PersistentVolumes (PV) are set up and support both `ReadWriteOnce` and `ReadWriteMany` and have minimum 1Gi storage.
@@ -120,19 +120,6 @@ If you would like to change the registry that's used at any time, run the `Codew
 
 **Note:** To proceed, you need to have added the registry credentials with Che.
 - Codewind restarts with the changes added.
-
-### Adding rules to support the Codewind odo extension
-The Codewind odo extension needs additional rules for accessing OpenShift resources. Use the following commands to clone the [`codewind-odo-extension`](https://github.com/eclipse/codewind-odo-extension) repository, create the ClusterRole with the required permissions, and bind that ClusterRole to the Che workspace service account:
-1. Log in to your OpenShift or Origin Community Distribution (OKD) cluster.
-2. Enter the following commands to go to the correct location, add the rules, and perform cleanup:
-```
-git clone https://github.com/eclipse/codewind-odo-extension &&\
-   cd ./codewind-odo-extension/odo-RBAC &&\
-   kubectl apply -f codewind-odoclusterrole.yaml &&\
-   kubectl apply -f codewind-odoclusterrolebinding.yaml &&\
-   cd - &&\
-   rm -rf codewind-odo-extension
-```
 
 ## Using Codewind from the Che Theia IDE
 

--- a/docs/_documentations/mdt-che-odo-support.md
+++ b/docs/_documentations/mdt-che-odo-support.md
@@ -11,28 +11,28 @@ parent: mdt-che-installinfo
 ---
 
 # OpenShift Do (odo) support in Codewind
-An extension to Codewind providing support for [OpenShift Do (odo)](https://github.com/openshift/odo). You can use the extension to write, build, and deploy components on OpenShift/OKD cluster efficiently.
+The extension to Codewind provides support for [OpenShift Do (odo)](https://github.com/openshift/odo). You can use the extension to efficiently write, build, and deploy components on an OpenShift or OKD cluster.
 
 1. [Extension overview](#overview)
 2. [Setting up extension](#setting-up-extension)
 3. [Current limitation](#current-limitation)
 
 ## Extension overview
-- Currently supports Java, Node.js, Python and Perl components. We will be supporting other languages in the future releases.
-- Provide OpenShift templates to help you create components with different supported languages.
-- You can import your existing components and continue to develop the components.
+- Supports Java, Node.js, Python, and Perl components.
+- Provides OpenShift templates to help you create components with different supported languages.
+- Imports your existing components and continues to develop the components.
 
 ## Setting up extension
 
 ### Adding rules to support the extension
-The extension needs additional rules for accessing OpenShift resources. Use the following commands to clone the [codewind-odo-extension](https://github.com/eclipse/codewind-odo-extension) repository, create the ClusterRole with the required permissions, and bind that ClusterRole to the Che workspace service account
+The extension needs additional rules for accessing OpenShift resources. Use the following commands to clone the [codewind-odo-extension](https://github.com/eclipse/codewind-odo-extension) repository, create the ClusterRole with the required permissions, and bind that ClusterRole to the Che workspace service account.
 
-### Importing Java image stream
-In order to create or import Java compoent, you need to import java image stream to your OpenShift/OKD cluster so that odo can build component image
+### Importing Java image stream to your OpenShift or OKD cluster
+In order to create or import Java compoent, you need to import Java image stream to your OpenShift or OKD cluster so that odo can build component image.
 
-### Steps to add rules and import java image stream
+### Adding rules and importing Java image stream
 1. Log in to your OpenShift or Origin Community Distribution (OKD) cluster.
-2. Enter the following commands to go to the correct location, add the rules and import java image stream, and perform cleanup:
+2. Enter the following commands to go to the correct location, add the rules and import Java image stream, and perform cleanup:
 ```
 git clone https://github.com/eclipse/codewind-odo-extension &&\
    cd ./codewind-odo-extension/setup &&\
@@ -44,5 +44,5 @@ git clone https://github.com/eclipse/codewind-odo-extension &&\
 ```
 
 ## Current limitation
-- Only support on Codewind for Eclipse Che with OKD/OpenShift cluster
-- Does not support debug mode
+- Only supports on Codewind for Eclipse Che with OKD/OpenShift cluster.
+- Does not support debug mode.

--- a/docs/_documentations/mdt-che-odo-support.md
+++ b/docs/_documentations/mdt-che-odo-support.md
@@ -1,0 +1,48 @@
+---
+layout: docs
+title: OpenShift Do (odo) support in Codewind
+description: OpenShift Do (odo) support in Codewind
+keywords: build, develop, deploy, install, installing, installation, Codewind for Eclipse Che, cloud, public cloud, services, command line, cli, command, devops, OpenShift, OKD, odo
+duration: 1 minute
+permalink: mdt-che-odo-support
+type: document
+order: 1
+parent: mdt-che-installinfo
+---
+
+# OpenShift Do (odo) support in Codewind
+An extension to Codewind providing support for [OpenShift Do (odo)](https://github.com/openshift/odo). You can use the extension to write, build, and deploy components on OpenShift/OKD cluster efficiently.
+
+1. [Extension overview](#overview)
+2. [Setting up extension](#setting-up-extension)
+3. [Current limitation](#current-limitation)
+
+## Extension overview
+- Currently supports Java, Node.js, Python and Perl components. We will be supporting other languages in the future releases.
+- Provide OpenShift templates to help you create components with different supported languages.
+- You can import your existing components and continue to develop the components.
+
+## Setting up extension
+
+### Adding rules to support the extension
+The extension needs additional rules for accessing OpenShift resources. Use the following commands to clone the [codewind-odo-extension](https://github.com/eclipse/codewind-odo-extension) repository, create the ClusterRole with the required permissions, and bind that ClusterRole to the Che workspace service account
+
+### Importing Java image stream
+In order to create or import Java compoent, you need to import java image stream to your OpenShift/OKD cluster so that odo can build component image
+
+### Steps to add rules and import java image stream
+1. Log in to your OpenShift or Origin Community Distribution (OKD) cluster.
+2. Enter the following commands to go to the correct location, add the rules and import java image stream, and perform cleanup:
+```
+git clone https://github.com/eclipse/codewind-odo-extension &&\
+   cd ./codewind-odo-extension/setup &&\
+   kubectl apply -f codewind-odoclusterrole.yaml &&\
+   kubectl apply -f codewind-odoclusterrolebinding.yaml &&\
+   ./odo-addbuilder.sh &&\
+   cd - &&\
+   rm -rf codewind-odo-extension
+```
+
+## Current limitation
+- Only support on Codewind for Eclipse Che with OKD/OpenShift cluster
+- Does not support debug mode

--- a/docs/_documentations/mdt-che-overview.md
+++ b/docs/_documentations/mdt-che-overview.md
@@ -14,7 +14,7 @@ parent: settingownide
 
 You can use Codewind for Eclipse Che to develop your containerized projects from within Eclipse Che.
 
-Use the Eclipse Che IDE to create and make modifications to your application, see the application and build status, view the logs, and run your application. Codewind for Eclipse Che supports development of OpenShift (Node.js, Python, Perl), Go, Java Lagom, Microprofile/Java EE, Node.js, Python, Spring, and Swift containerized projects.
+Use the Eclipse Che IDE to create and make modifications to your application, see the application and build status, view the logs, and run your application. Codewind for Eclipse Che supports development of OpenShift (Java, Node.js, Python, Perl), Go, Java Lagom, Microprofile/Java EE, Node.js, Python, Spring, and Swift containerized projects.
 
 To install Codewind for Eclipse Che, see [Installing Codewind for Eclipse Che](mdt-che-installinfo.html).
 

--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -23,7 +23,7 @@ The following sections contain workarounds for issues that you might encounter w
 * [Editing your project](#editing-your-project)
 * [Disabling development on specific projects](#disabling-development-on-specific-projects)
 * [Appsody with Codewind](#appsody-with-codewind)
-* [ODO with Codewind](#odo-with-codewind)
+* [OpenShift Do (odo) with Codewind](#openshift-do-(odo)-with-codewind)
 * [OKD and OpenShift](#okd-and-openshift)
 * [Codewind and Tekton pipelines](#codewind-and-tekton-pipelines)
 * [OpenAPI tools](#openapi-tools)
@@ -459,46 +459,7 @@ Codewind displays an error. In VS Code, the error appears in the Codewind log:
 3. Rebind the project to Codewind.
 
 ***
-# ODO with Codewind
-
-<!--
-Codewind version: 0.5.0
-Che version: 7.2.0
-IDE extension version: 0.5.0
-IDE version: **7.1.0
-Action/Topic: ODO with Codewind
-Issue type: bug/info
-Issue link: https://github.com/eclipse/codewind/issues/692
--->
-## ODO projects are not deleted after the workspace is deleted
-
-If you create ODO projects and then delete the workspace without deleting the projects, all your ODO deployments still exist. 
-
-These steps reproduce the issue: 
-1. Install Codewind Che.
-2. Create ODO projects.
-3. Delete the Codewind workspace.
-4. Create a new workspace. You still see previously created ODO project deployments.
-
-**Workaround** 
-1. Login to the OKD/OpenShift cluster.
-2. Change to the project where the resources are by running the following command: 
-
-   ```sh
-   oc project <project name>
-   ```
-
-3. Delete the ODO project resources by running the following command: 
-
-   ```sh
-   oc delete svc,route,dc,pvc,is -l=app.kubernetes.io/part-of=app
-   ```
-
-   Or for individual components:
-
-   ```sh
-   oc delete svc,route,dc,pvc,is -l=app.kubernetes.io/instance=<component>
-   ```
+# OpenShift Do (odo) with Codewind
 
 ***
 # OKD and OpenShift


### PR DESCRIPTION
Issue: https://github.com/eclipse/codewind/issues/1111

This PR is for adding separate odo extension documentation, it includes:
- OpenShift Do (odo) support in Codewind overview
- Adding additional rules to support building OpenShift projects
- Bind case
- odo java component/builder setup (image stream configuration)
- Update troubleshooting page
- Update installation and Codewind for Eclipse Che overview pages

Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>