### PR TITLE
Reword Codewind remote

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -64,13 +64,13 @@
         - title: 'Installing Kibana and filtering logs in IBM Cloud Private'
           url: viewkibanalogs.html
 
-- title: 'Deploying Codewind remote'
+- title: 'Deploying Codewind remotely'
   children:
     - title: 'Overview'
       url: remoteoverview.html
-    - title: 'Configuring Codewind remote'
+    - title: 'Configuring your remote deployment of Codewind'
       url: remoteconfiguring.html
-    - title: 'Removing Codewind remote'
+    - title: 'Removing your remote deployment of Codewind'
       url: remoteremoving.html
 
 - title: 'Performance monitoring'

--- a/docs/_documentations/remote-configuring.md
+++ b/docs/_documentations/remote-configuring.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
-title: Configuring Codewind remote
-description: Configuring your environment to use Codewind remote
+title: Configuring your remote deployment of Codewind
+description: Configuring your environment to use your remote deployment of Codewind
 keywords: users, projects, Kubernetes, LDAP, user management, access management, login, deployment, pod, security, securing cloud connection
 duration: 5 minutes
 permalink: remoteconfiguring
@@ -10,9 +10,9 @@ parent: installoncloud
 order: 1
 ---
 
-# Configuring Codewind remote
+# Configuring your remote deployment of Codewind
 
-To use Codewind remote, configure your system by following these steps. 
+Configure your remote deployment of Codewind by following these steps. 
 
 ## Prerequisites
 - Install your preferred IDE on your local machine. For more information about installing Eclipse, see [Getting started with Codewind for Eclipse](mdteclipsegettingstarted.html), or for more information about installing VS Code, see [Getting started with Codewind for VS Code](mdt-vsc-getting-started.html).
@@ -21,7 +21,7 @@ To use Codewind remote, configure your system by following these steps.
 
 ## Procedure
 
-To securely configure Codewind remote there are two options, configuring Kubernetes for Docker Desktop, or configuring a cloud deployment that does not have an Ingress NGINX controller, for example, OpenShift. 
+To securely configure your remote deployment of Codewind, there are two options, configuring Kubernetes for Docker Desktop, or configuring a cloud deployment that does not have an Ingress NGINX controller, for example, OpenShift. 
 
 ### Configuring Kubernetes for Docker Desktop
 
@@ -39,7 +39,7 @@ To securely configure Codewind remote there are two options, configuring Kuberne
    - `export INGRESS_DOMAIN=$(kubectl get services --namespace ingress-nginx -o jsonpath='<.items[*].spec.clusterIP>')`
    - `sudo ifconfig lo0 alias $<INGRESS_DOMAIN>`
 
-3. Create the remote deployment by entering the following `cwctl` command: 
+3. Create the remote deployment of Codewind by entering the following `cwctl` command: 
 
    `cwctl install remote \`
      `--namespace <your_namespace>  \`
@@ -56,7 +56,7 @@ To securely configure Codewind remote there are two options, configuring Kuberne
 
 1. If you are deploying to a cloud that does not have an Ingress NGINX controller, for example, OpenShift, you must provide the ingress value in the `cwctl install remote \` command during installation. You can derive the `ingress` value from the cluster URL. To do this, go to the OpenShift console, for example, `https://<mycluster>|<myaddress>.nip.io:7443/console`, and then derive the `ingress` value, for example, from the previous address, this would be `apps.<mycluster>.<myaddress>.nip.io`. OpenShift also refer to this as the `routing-suffix`. 
 
-2. Create the remote deployment by issuing the following example `cwctl` command: 
+2. Create the remote deployment of Codewind by issuing the following example `cwctl` command: 
 
    `cwctl install remote \`
      `--namespace <your_namespace>  \`

--- a/docs/_documentations/remote-overview.md
+++ b/docs/_documentations/remote-overview.md
@@ -1,8 +1,8 @@
 ---
 layout: docs
-title: Deploying Codewind remote
-description: Deploying Codewind remote
-keywords: users, projects, Kubernetes, LDAP, user management, access management, login, deployment, pod, security, securing cloud connection
+title: Deploying Codewind remotely
+description: Deploying Codewind remotely
+keywords: users, projects, Kubernetes, LDAP, user management, access management, login, deployment, pod, security, securing cloud connection, remote deployment of Codewind
 duration: 5 minutes
 permalink: remoteoverview
 type: document
@@ -10,9 +10,9 @@ parent: installoncloud
 order: 1
 ---
 
-# Deploying Codewind remote
+# Deploying Codewind remotely
 
-Codewind remote is where you develop your code locally and build and run it remotely and securely in the cloud. This option is incredibly useful because it frees up your local machine to focus purely on developing code and you use the cloud's resources to build and run your apps. Codewind enables you to develop your apps securely by securing the connection between your local editor and your remote cloud deployment. To do this, Codewind uses Keycloak, an open source identity and access management solution for modern applications and services which is highly configurable to your environment. 
+Deploying Codewind remotely is where you deploy Codewind in the cloud. You then develop your code locally and build and run it remotely and securely using your remote deployment of Codewind. This option is incredibly useful because it frees up your local machine to focus purely on developing code and you use the cloud's resources to build and run your apps. Codewind enables you to develop your apps securely by securing the connection between your local editor and your remote cloud deployment. To do this, Codewind uses Keycloak, an open source identity and access management solution for modern applications and services which is highly configurable to your environment. 
 
 You install your preferred IDE on your local machine. For more information about installing Eclipse, see [Getting started with Codewind for Eclipse](mdteclipsegettingstarted.html), or for more information about installing VS Code, see [Getting started with Codewind for VS Code](mdt-vsc-getting-started.html).
 
@@ -22,7 +22,7 @@ You then use the Codewind features inside your preferred IDE to create a connect
 
 Codewind enables you to choose which preferred IDE you want to use, however do not use two different IDEs at the same time. For the best user experience, choose which one you want to use, and disable the other. 
 
-To configure Codewind remote, see [Configuring Codewind remote](remoteconfiguring.html).
+To configure your remote deployment of Codewind, see [Configuring your remote deployment of Codewind](remoteconfiguring.html).
 
 ## Codewind remote security overview
 

--- a/docs/_documentations/remote-overview.md
+++ b/docs/_documentations/remote-overview.md
@@ -12,7 +12,7 @@ order: 1
 
 # Deploying Codewind remotely
 
-Deploying Codewind remotely is where you deploy Codewind in the cloud. You then develop your code locally and build and run it remotely and securely using your remote deployment of Codewind. This option is incredibly useful because it frees up your local machine to focus purely on developing code and you use the cloud's resources to build and run your apps. Codewind enables you to develop your apps securely by securing the connection between your local editor and your remote cloud deployment. To do this, Codewind uses Keycloak, an open source identity and access management solution for modern applications and services which is highly configurable to your environment. 
+Deploying Codewind remotely enables you to develop your code locally and then build and run it remotely and securely in the cloud. This option is incredibly useful because it frees up local resource usage and you use the cloud's resources to build and run your apps. By using [Keycloak](https://www.keycloak.org/), the connection between your local editor and your remote cloud deployment is secure.
 
 You install your preferred IDE on your local machine. For more information about installing Eclipse, see [Getting started with Codewind for Eclipse](mdteclipsegettingstarted.html), or for more information about installing VS Code, see [Getting started with Codewind for VS Code](mdt-vsc-getting-started.html).
 

--- a/docs/_documentations/remote-removing.md
+++ b/docs/_documentations/remote-removing.md
@@ -16,11 +16,12 @@ The Codewind CLI `cwctl` is designed to do almost all the steps required to remo
 
 There are two modes of use. You can:
 1. Remove Codewind.
-2. Remove Keycloak. A Keycloak service can provide authentication services to many Codewind deployments in different namespaces, so only remove it if you are sure it is no longer used.
+2. Remove Keycloak. A Keycloak service can provide authentication services to many Codewind deployments in different namespaces, so only remove it when you are sure it is no longer used.
 
 ## Removing a remote deployment of Codewind
 
 To remove a remote deployment of Codewind, enter the following `cwctl` command:
+
 `cwctl remove remote --namespace <namespace> --workspace <workspaceID>`
 
 Where the command parameters `<namespace>` and `<workspaceID>` are used to identify which Kubernetes resources to remove. If you are unsure of the `<workspaceID>`, you can find it as part of the ingress or route URL, for example:
@@ -32,7 +33,8 @@ Where the command parameters `<namespace>` and `<workspaceID>` are used to ident
 
 WARNING: Removing Keycloak breaks all remote deployments of Codewind that are using it for authentication services. 
 
-If you are ready to remove keycloak, use the following `cwctl` command:
-`cwctl remove keycloak  --namespace <namespace> keycloak-only --workspace <workspaceID>`
+If you are ready to remove Keycloak, use the following `cwctl` command:
+
+`cwctl remove keycloak  --namespace <namespace> --workspace <workspaceID>`
 
 Where the command parameters `<namespace>` and `<workspaceID>` are used to identify which Kubernetes resources to remove.

--- a/docs/_documentations/remote-removing.md
+++ b/docs/_documentations/remote-removing.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
-title: Removing Codewind remote
-description: Removing Codewind remote
+title: Removing your remote deployment of Codewind
+description: Removing your remote deployment of Codewind
 keywords: users, projects, Kubernetes, LDAP, user management, access management, login, deployment, pod, security, securing cloud connection
 duration: 5 minutes
 permalink: remoteremoving
@@ -10,7 +10,8 @@ parent: installoncloud
 order: 1
 ---
 
-## Removing Codewind remote
+## Removing your remote deployment of Codewind
 
-To remove Codewind remote, enter the following `cwctl` command: `cwctl remove remote --namespace {mynamespace} --workspace {workspaceID}`
+To remove your remote deployment of Codewind, enter the following `cwctl` command: 
+`cwctl remove remote --namespace {mynamespace} --workspace {workspaceID}`
 

--- a/docs/_documentations/remote-removing.md
+++ b/docs/_documentations/remote-removing.md
@@ -10,8 +10,29 @@ parent: installoncloud
 order: 1
 ---
 
-## Removing your remote deployment of Codewind
+# Removing your remote deployment of Codewind
 
-To remove your remote deployment of Codewind, enter the following `cwctl` command: 
-`cwctl remove remote --namespace {mynamespace} --workspace {workspaceID}`
+The Codewind CLI `cwctl` is designed to do almost all the steps required to remove a remote deployment of Codewind by chaining together a number of Kubernetes operations.
 
+There are two modes of use. You can:
+1. Remove Codewind.
+2. Remove Keycloak. A Keycloak service can provide authentication services to many Codewind deployments in different namespaces, so only remove it if you are sure it is no longer used.
+
+## Removing a remote deployment of Codewind
+
+To remove a remote deployment of Codewind, enter the following `cwctl` command:
+`cwctl remove remote --namespace <namespace> --workspace <workspaceID>`
+
+Where the command parameters `<namespace>` and `<workspaceID>` are used to identify which Kubernetes resources to remove. If you are unsure of the `<workspaceID>`, you can find it as part of the ingress or route URL, for example:
+
+`https://codewind-gatekeeper-k412oms7.apps.mycluster.X.X.X.X.nip.io`
+`                            ^^^^^^^^`
+
+## Removing Keycloak
+
+WARNING: Removing Keycloak breaks all remote deployments of Codewind that are using it for authentication services. 
+
+If you are ready to remove keycloak, use the following `cwctl` command:
+`cwctl remove keycloak  --namespace <namespace> keycloak-only --workspace <workspaceID>`
+
+Where the command parameters `<namespace>` and `<workspaceID>` are used to identify which Kubernetes resources to remove.


### PR DESCRIPTION
Signed-off-by: micgibso <micgibso@uk.ibm.com>

Reword Codewind remote, this from PR https://github.com/eclipse/codewind-docs/pull/257 where @tobespc commented: `Codewind remote - this is used a lot as though it's a thing; should be a remote deployment of codewind`