### PR TITLE
[This branch to be deleted] Replaced markdown emojis with emojipedia workaround

### DIFF
--- a/docs/_data/newstoc.yml
+++ b/docs/_data/newstoc.yml
@@ -1,3 +1,6 @@
+- title: 'Codewind 0.7.0'
+  url: news07.html
+
 - title: 'Codewind 0.6.0'
   url: news06.html
 

--- a/docs/_news/news07.md
+++ b/docs/_news/news07.md
@@ -2,19 +2,31 @@
 layout: news
 title: New for Codewind 0.7.0
 description: New for Codewind 0.7.0
-keywords: news, new, updates, update, version
+keywords: news, new, updates, update, version, hybrid
 duration: 1 minute
 permalink: news07
 ---
 
 ## Codewind 0.7.0
-(new date)
+// DOUBLE CHECK -- Monday 16 December 2019
 
-#### New Features and Highlights
+#### :sparkles: Remote Deploy with Codewind: Tech Preview :sparkles:
 
-// TODO: Insert a giphy of project bind support
+You can now develop your code locally and securetly build and deploy your apps in the cloud! Why is this cool?
+- Free up local resources. :clap:
+- It's secure! We use [Keycloak](https://keycloak.org/) to secure the connection between your local editor and remote cloud deployment.
+
+// Curious? [Try it out!](link to docs) or [learn more](Link to our tech preview blog)
+
+#### New Features and Highlights for 0.7.0
+
+**OpenShift Do (odo)**
+- You can now easily import existing projects into Codewind and [use odo](https://github.com/eclipse/codewind/issues/1115) to build and deploy projects to your OpenShift or OKD cluster
+- Introducing [support for Java template](https://github.com/eclipse/codewind/issues/450) and Java projects can build and deploy [once configured](//permalink to landing page)
+- You no longer have to create your [docker registry secret](https://github.com/eclipse/codewind/issues/665) in Codewind 
+
 
 #### List of Fixes
-// codewind-openapi-eclipse, port vscode behavior to eclipse for post processing  (https://github.com/eclipse/codewind/issues/1116)
-// codewind-appsody-extension - updated appsody binary
-
+- Changes to the Eclipse plugin for Spring Server [post-code generation stability for OpenAPI](https://github.com/eclipse/codewind/issues/1116)
+- Appsody binary updated from 0.5.0 to 0.5.2 in the codewind-appsody-extension
+- Other security fixes

--- a/docs/_news/news07.md
+++ b/docs/_news/news07.md
@@ -1,0 +1,20 @@
+---
+layout: news
+title: New for Codewind 0.7.0
+description: New for Codewind 0.7.0
+keywords: news, new, updates, update, version
+duration: 1 minute
+permalink: news07
+---
+
+## Codewind 0.7.0
+(new date)
+
+#### New Features and Highlights
+
+// TODO: Insert a giphy of project bind support
+
+#### List of Fixes
+// codewind-openapi-eclipse, port vscode behavior to eclipse for post processing  (https://github.com/eclipse/codewind/issues/1116)
+// codewind-appsody-extension - updated appsody binary
+

--- a/docs/_news/news07.md
+++ b/docs/_news/news07.md
@@ -8,15 +8,15 @@ permalink: news07
 ---
 
 ## Codewind 0.7.0
-// DOUBLE CHECK -- Monday 16 December 2019
+Monday 16 December 2019
 
-#### :sparkles: Remote Deploy with Codewind: Tech Preview :sparkles:
+#### ✨ Remote Deploy with Codewind: Tech Preview ✨
 
 You can now develop your code locally and securely build and deploy your apps in the cloud! Why is this cool?
-- Free up local resources. :clap:
-- It's secure! We use [Keycloak](https://keycloak.org/) to secure the connection between your local editor and remote cloud deployment.
+- Free up local resources. 👏
+- It's secure! 🔐 We use [Keycloak](https://keycloak.org/) to secure the connection between your local editor and remote cloud deployment.
 
-// Curious? [Try it out!](link to docs) or [learn more](Link to our tech preview blog).
+// Curious? [Try it out!](link to docs) and keep an eye out for more information!
 
 #### New Features and Highlights for 0.7.0
 

--- a/docs/_news/news07.md
+++ b/docs/_news/news07.md
@@ -12,18 +12,18 @@ permalink: news07
 
 #### :sparkles: Remote Deploy with Codewind: Tech Preview :sparkles:
 
-You can now develop your code locally and securetly build and deploy your apps in the cloud! Why is this cool?
+You can now develop your code locally and securely build and deploy your apps in the cloud! Why is this cool?
 - Free up local resources. :clap:
 - It's secure! We use [Keycloak](https://keycloak.org/) to secure the connection between your local editor and remote cloud deployment.
 
-// Curious? [Try it out!](link to docs) or [learn more](Link to our tech preview blog)
+// Curious? [Try it out!](link to docs) or [learn more](Link to our tech preview blog).
 
 #### New Features and Highlights for 0.7.0
 
 **OpenShift Do (odo)**
-- You can now easily import existing projects into Codewind and [use odo](https://github.com/eclipse/codewind/issues/1115) to build and deploy projects to your OpenShift or OKD cluster
-- Introducing [support for Java template](https://github.com/eclipse/codewind/issues/450) and Java projects can build and deploy [once configured](//permalink to landing page)
-- You no longer have to create your [docker registry secret](https://github.com/eclipse/codewind/issues/665) in Codewind 
+- You can now easily import existing projects into Codewind and [use odo](https://github.com/eclipse/codewind/issues/1115) to build and deploy projects to your OpenShift or OKD cluster.
+- Introducing [support for Java template](https://github.com/eclipse/codewind/issues/450) and Java projects can build and deploy [once configured](//permalink to landing page).
+- You no longer have to create your [docker registry secret](https://github.com/eclipse/codewind/issues/665) in Codewind.
 
 
 #### List of Fixes

--- a/docs/_news/news07.md
+++ b/docs/_news/news07.md
@@ -16,7 +16,7 @@ You can now develop your code locally and securely build and deploy your apps in
 - Free up local resources. 👏
 - It's secure! 🔐 We use [Keycloak](https://keycloak.org/) to secure the connection between your local editor and remote cloud deployment.
 
-// Curious? [Try it out!](link to docs) and keep an eye out for more information!
+Curious? [Try it out](remoteoverview.html) and keep an eye out for more information!
 
 #### New Features and Highlights for 0.7.0
 
@@ -24,6 +24,7 @@ You can now develop your code locally and securely build and deploy your apps in
 - You can now easily import existing projects into Codewind and [use odo](https://github.com/eclipse/codewind/issues/1115) to build and deploy projects to your OpenShift or OKD cluster.
 - Introducing [support for Java template](https://github.com/eclipse/codewind/issues/450) and Java projects can build and deploy [once configured](//permalink to landing page).
 - You no longer have to create your [docker registry secret](https://github.com/eclipse/codewind/issues/665) in Codewind.
+
 
 
 #### List of Fixes


### PR DESCRIPTION
Replaced the `:sparkles:` and `:clap:` markdown emojis with pasted values from emojipedia, as well as added one for security (lock&key). 

- Removed comment for date of publish
- Waiting to get real links for the `Try it out` and waiting on more info from other teams for fixes and updates to incorporate into our notes