### PR TITLE
updated TOC for image registry doc

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -66,6 +66,11 @@
         - title: 'Installing Kibana and filtering logs in IBM Cloud Private'
           url: viewkibanalogs.html
 
+    - title: 'Specifying image registries for Codewind'
+      children: 
+        - title: 'Specifying image registries for Codewind'
+        - url: image-registry-credentials.html
+
 - title: 'Deploying Codewind remotely'
   children:
     - title: 'Overview'


### PR DESCRIPTION
Signed-off-by: Jacob Berger <jacob.berger@ibm.com>

For issue 1178: https://github.com/eclipse/codewind/issues/1178

Changed the TOC to reflect the new placement of `image-registry` doc 

@sishida ready for your to review, approve, merge, and close! 