### PR TITLE
Update che/kube docs for 0.8.0

### DIFF
--- a/docs/_documentations/mdt-che-installinfo.md
+++ b/docs/_documentations/mdt-che-installinfo.md
@@ -28,7 +28,7 @@ Installing Codewind for Eclipse Che comprises the following steps:
    - Because Codewind uses RWX (ReadWriteMany) volumes to provide persistent storage, you need to use NFS for storage on OpenShift 4.
 2. Ensure that the cluster can pull images from `docker.io/eclipse` and `quay.io/eclipse`.
    - Both Eclipse Che and Eclipse Codewind host their Docker images at those locations. Ensure that your cluster can pull from that registry and does not have `ImagePullPolicies` blocking it from accessing Docker Hub.
-3. Set up the ClusterRole for Codewind. Run `kubectl apply -f https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.7.0/setup/install_che/codewind-clusterrole.yaml`
+3. Set up the ClusterRole for Codewind. Run `kubectl apply -f https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.8.0/setup/install_che/codewind-clusterrole.yaml`
 
 # Setting up Che
 
@@ -38,7 +38,7 @@ The fastest way to install Eclipse Che for use with Codewind is to use the `chec
 
 Complete the following steps after you install `chectl`:
 
-1. Download the [codewind-checluster.yaml](https://github.com/eclipse/codewind-che-plugin/blob/0.7.0/setup/install_che/che-operator/codewind-checluster.yaml) file to your machine.
+1. Download the [codewind-checluster.yaml](https://github.com/eclipse/codewind-che-plugin/blob/0.8.0/setup/install_che/che-operator/codewind-checluster.yaml) file to your machine.
     - You can modify this file, but leave the `spec.server.cheWorkspaceClusterRole` field set to `eclipse-codewind` and the `spec.storage.preCreateSubPaths` field set to `true`.
 2. If you're installing on a Kubernetes platform other than OpenShift, determine your Ingress domain. If you're unsure of your Ingress domain, ask your cluster administrator.
     - Set the `spec.server.ingressDomain` field in the Che `.yaml` to the Ingress domain.
@@ -51,7 +51,7 @@ Complete the following steps after you install `chectl`:
 If you already have an existing Che install, it's relatively easy to update it for Codewind.
 
 After creating the Codewind ClusterRole in the prerequisites step, run the following command, where `$NAMESPACE` is the namespace your Che workspaces run in (by default `che`):
-`kubectl apply -f https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.7.0/setup/install_che/codewind-rolebinding.yaml -n $NAMESPACE`
+`kubectl apply -f https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.8.0/setup/install_che/codewind-rolebinding.yaml -n $NAMESPACE`
 
 ### Enabling privileged and root containers to run
 
@@ -86,7 +86,7 @@ http://<che ingress domain>/f?url=<hosted devfile URL>
 
 Codewind includes a ready-to-use devfile with its plug-ins. Enter the following URL to create a workspace from the devfile:
 ```
-http://<che ingress domain>/f?url=https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.7.0/devfiles/0.7.0/devfile.yaml
+http://<che ingress domain>/f?url=https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.8.0/devfiles/0.8.0/devfile.yaml
 ```
 
 For other sample devfiles, see https://github.com/kabanero-io/codewind-templates/tree/master/devfiles.

--- a/docs/_documentations/mdt-che-odo-support.md
+++ b/docs/_documentations/mdt-che-odo-support.md
@@ -34,7 +34,7 @@ In order to create or import Java compoent, you need to import Java image stream
 1. Log in to your OpenShift or Origin Community Distribution (OKD) cluster.
 2. Enter the following commands to go to the correct location, add the roles and import the Java image stream, and perform cleanup:
 ```
-git clone https://github.com/eclipse/codewind-odo-extension &&\
+git clone -b 0.8.0 https://github.com/eclipse/codewind-odo-extension &&\
    cd ./codewind-odo-extension/setup &&\
    ./setup.sh
    cd - &&\


### PR DESCRIPTION
This PR updates the Codewind docs to use resources from the 0.8.0 branch, not 0.7.0 or master, when installing Codewind on Kube and setting up the odo extension.