### PR TITLE
[master] Remove odo branch label

### DIFF
--- a/docs/_documentations/mdt-che-odo-support.md
+++ b/docs/_documentations/mdt-che-odo-support.md
@@ -34,7 +34,7 @@ In order to create or import Java compoent, you need to import Java image stream
 1. Log in to your OpenShift or Origin Community Distribution (OKD) cluster.
 2. Enter the following commands to go to the correct location, add the roles and import the Java image stream, and perform cleanup:
 ```
-git clone -b 0.8.0 https://github.com/eclipse/codewind-odo-extension &&\
+git clone https://github.com/eclipse/codewind-odo-extension &&\
    cd ./codewind-odo-extension/setup &&\
    ./setup.sh
    cd - &&\


### PR DESCRIPTION
This PR https://github.com/eclipse/codewind-docs/pull/284 backports changes to `codewind-docs` master branch.

However, in `codewind-docs` master branch, we should always point to the instruction/script from `odo extension` master branch instead of release branch.

Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>