### PR TITLE
add extra margins to the heading, also underline h1 and h2

### DIFF
--- a/docs/css/docs.css
+++ b/docs/css/docs.css
@@ -3,6 +3,20 @@
     margin-right: 0;
 }
 
+h1, h2 {
+	padding-bottom: .3em;
+    border-bottom: 1px solid #eaecef;
+}
+
+b, strong {
+    font-weight: 600;
+}
+
+h1, h2, h3, h4, h5, h6 {
+	margin-bottom: 1em;
+    margin-top: 1em;
+}
+
 code {
 	font-size: 14px !important;
 }


### PR DESCRIPTION
Added extra margins to the headings.
also added underline to the H1 and H2 headings.

https://github.com/eclipse/codewind/issues/512

Signed-off-by: tiaoyuw <tiaoyuw@ca.ibm.com>