### PR TITLE
document statusPingTimeout setting for cw-settings

### DIFF
--- a/docs/_documentations/mdt-eclipse-managingprojects.md
+++ b/docs/_documentations/mdt-eclipse-managingprojects.md
@@ -119,6 +119,6 @@ The list of supported project settings are:
 
 #### Project status ping timeout
 `statusPingTimeout: <string>`
-- This value is the total number of pings used by Codewind to determine if the project has timeout issue during starting state.
-- Each ping takes 2 seconds. e.g. if the value is set to 30, the timeout is 60 seconds.
+- This value is the total number of pings used by Codewind to determine if the project has timeout issues during starting state.
+- Each ping takes 2 seconds. For example, if the value is set to 30, the timeout is 60 seconds.
 - If the value is not set, the default value is set to `90` (3 minutes) for Appsody projects, and `30` (1 minute) for all other project types.   

--- a/docs/_documentations/mdt-eclipse-managingprojects.md
+++ b/docs/_documentations/mdt-eclipse-managingprojects.md
@@ -60,6 +60,7 @@ The list of supported project settings are:
 * [Maven profiles](#maven-profiles)
 * [Maven properties](#maven-properties)
 * [Paths to ignore for file changes](#paths-to-ignore-for-file-changes)
+* [Project status ping timeout](#project-status-ping-timeout)
 
 
 #### Context root
@@ -115,3 +116,9 @@ The list of supported project settings are:
 `ignoredPaths: <string[]>`
 - A list of file paths that indicate a build should be triggered on file change events in relation to the paths.
 - Each item is expected to be a regex (`"*/node_modules*"` ) or a path relative to the project's root directory (`"/README.md"`).
+
+#### Project status ping timeout
+`statusPingTimeout: <string>`
+- This value is the total number of pings used by Codewind to determine if the project has timeout issue during starting state.
+- Each ping takes 2 seconds. e.g. if the value is set to 30, the timeout is 60 seconds.
+- If the value is not set, the default value is set to `90` (3 minutes) for Appsody projects, and `30` (1 minute) for all other project types.   

--- a/docs/_documentations/mdt-vsc-commands-project.md
+++ b/docs/_documentations/mdt-vsc-commands-project.md
@@ -123,8 +123,8 @@ The list of supported project settings are:
 
 #### Project status ping timeout
 `statusPingTimeout: <string>`
-- This value is the total number of pings used by Codewind to determine if the project has timeout issue during starting state.
-- Each ping takes 2 seconds. e.g. if the value is set to 30, the timeout is 60 seconds.
+- This value is the total number of pings used by Codewind to determine if the project has timeout issues during starting state.
+- Each ping takes 2 seconds. For example, if the value is set to 30, the timeout is 60 seconds.
 - If the value is not set, the default value is set to `90` (3 minutes) for Appsody projects, and `30` (1 minute) for all other project types.  
 
 ***

--- a/docs/_documentations/mdt-vsc-commands-project.md
+++ b/docs/_documentations/mdt-vsc-commands-project.md
@@ -65,6 +65,7 @@ The list of supported project settings are:
 * [Internal debug port](#internal-debug-port)
 * [Maven profiles](#maven-profiles)
 * [Paths to ignore for file changes](#paths-to-ignore-for-file-changes)
+* [Project status ping timeout](#project-status-ping-timeout)
 
 #### **Context root**
 `contextRoot: <string>`
@@ -119,6 +120,12 @@ The list of supported project settings are:
 - Maven properties can be entered in the form `key=value`
 - It is not advised to overwrite the microclimate property
 - Maven properties can be used in conjunction with Maven profiles
+
+#### Project status ping timeout
+`statusPingTimeout: <string>`
+- This value is the total number of pings used by Codewind to determine if the project has timeout issue during starting state.
+- Each ping takes 2 seconds. e.g. if the value is set to 30, the timeout is 60 seconds.
+- If the value is not set, the default value is set to `90` (3 minutes) for Appsody projects, and `30` (1 minute) for all other project types.  
 
 ***
 


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

PR for issue: https://github.com/eclipse/codewind/issues/1847