### PR TITLE
Making permalink lowercase, removing parent value

### DIFF
--- a/docs/_documentations/overview.md
+++ b/docs/_documentations/overview.md
@@ -4,9 +4,8 @@ title: What is Codewind?
 description: What is Codewind?
 keywords: IDE, cloud native, kubernetes, cloud, development, VS Code, Eclipse, Eclipse Che, templates, local, remote, hosted, overview, prerequisites
 duration: 2 minute
-permalink: Overview
+permalink: overview
 type: document
-parent: root
 ---
 
 # What is Codewind?


### PR DESCRIPTION
The new "What is Codewind?" link in the table of contents currently doesn't work. I think making the permalink lowercase and maybe removing the parent value could help?