### PR TITLE
Correcting URL

### DIFF
--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -524,7 +524,7 @@ For Codewind to work with an Appsody stack image on a private Docker registry, t
 - **Note:** When you view the application log, you might see failures to pull the image during a rebuild. However, Codewind is taking the cached container image from your local machine. If you ever delete that image, you need to pull the image again. You can either create another project from the same stack or manually call a `docker pull` with the required image.
 
 **Remote scenario**
-Follow the instructions in [Adding a container registry in Codewind](mdt-che-setupregistries.html).
+Follow the instructions in [Adding a container registry in Codewind](image-registry-credentials.html).
 
 ***
 # OpenShift Do (odo) with Codewind


### PR DESCRIPTION
In a PR in a different branch (https://github.com/eclipse/codewind-docs/pull/391), Steven pointed out that the URL needs to be changed to image-registry-credentials.html. Now, I'm updating the master branch to have the same change.