### PR TITLE
Fixed broken links for 0.9.0

### DIFF
--- a/docs/_documentations/mdt-vsc-commands-restart-and-debug.md
+++ b/docs/_documentations/mdt-vsc-commands-restart-and-debug.md
@@ -38,6 +38,4 @@ Next, the launch configuration runs, and the VS Code debugger attaches to your a
 
 [Back to the commands overview](mdt-vsc-commands-overview.html)
 
-[Back to the VS Code tools overview](mdt-vsc-overview.html)
-
 [Troubleshooting](mdt-vsc-troubleshooting.html)

--- a/docs/_news/news07.md
+++ b/docs/_news/news07.md
@@ -16,7 +16,7 @@ You can now develop your code locally and securely build and deploy your apps in
 - Free up local resources. 👏
 - It's secure! 🔐 We use [Keycloak](https://keycloak.org/) to secure the connection between your local editor and remote cloud deployment.
 
-Curious? [Learn more](remoteoverview.html)!
+Curious? [Learn more](remote-overview.html)!
 
 #### New Features and Highlights for 0.7.0
 


### PR DESCRIPTION
Signed-off-by: Jacob Berger <jacob.berger@ibm.com>

Issue 2270: https://github.com/eclipse/codewind/issues/2270

The new link works on the test server, and the broken link notification did not appear when I ran `./build.sh` 

