### PR TITLE
Adding mdt-che-createfirstproject to TOC

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -28,6 +28,8 @@
         url: mdt-che-setupregistries.html
       - title: 'Creating a Codewind workspace in Che'
         url: mdt-che-createcodewindworkspace.html
+      - title: 'Creating your first project with Codewind for Eclipse Che'
+        url: mdt-che-createfirstproject.html
       - title: 'Setup to use Tekton Pipelines'
         url: mdt-che-tektonpipelines.html
       - title: 'Using Codewind in Theia'


### PR DESCRIPTION
Adding "Creating your first project with Codewind for Eclipse Che" (mdt-che-createfirstproject.md) file to table of contents.