### PR TITLE
Remove mdt- from doc source

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -7,35 +7,35 @@
     - title: 'VS Code'
       children:
       - title: 'Installing Codewind for VS Code'
-        url: mdt-vsc-getting-started.html
+        url: vsc-getting-started.html
       - title: 'Creating your first project'
-        url: mdt-vsc-firstproject.html
+        url: vsc-firstproject.html
       - title: 'Making a code change'
         url: vsc-codechange.html
     - title: 'Eclipse'
       children:
       - title: 'Installing Codewind for Eclipse'
-        url: mdt-eclipse-getting-started.html
+        url: eclipse-getting-started.html
       - title: 'Creating your first project'
-        url: mdt-eclipse-firstproject.html
+        url: eclipse-firstproject.html
       - title: 'Making a code change'
-        url: mdt-eclipse-codechange.html
+        url: eclipse-codechange.html
     - title: 'Eclipse Che'
       children:
       - title: 'Installing Eclipse Che for Codewind'
-        url: mdt-che-installinfo.html
+        url: che-installinfo.html
       - title: 'Adding registries in Che'
-        url: mdt-che-setupregistries.html
+        url: che-setupregistries.html
       - title: 'Creating a Codewind workspace in Che'
-        url: mdt-che-createcodewindworkspace.html
+        url: che-createcodewindworkspace.html
       - title: 'Creating your first project with Codewind for Eclipse Che'
-        url: mdt-che-createfirstproject.html
+        url: che-createfirstproject.html
       - title: 'Setup to use Tekton Pipelines'
-        url: mdt-che-tektonpipelines.html
+        url: che-tektonpipelines.html
       - title: 'Using Codewind in Theia'
-        url: mdt-che-usingtheia.html
+        url: che-usingtheia.html
       - title: 'OpenShift Do (odo) support in Codewind'
-        url: mdt-che-odo-support.html         
+        url: che-odo-support.html         
       - title: 'Using the OpenShift Registry'
         url: openshiftregistry.html
       - title: 'Support for multiple users'
@@ -43,11 +43,11 @@
       - title: 'Installing Kibana and filtering logs in IBM Cloud Private'
         url: viewkibanalogs.html
       - title: 'Uninstalling Codewind for Eclipse Che'
-        url: mdt-che-uninstall.html
+        url: che-uninstall.html
     - title: 'IntelliJ'
       children:
       - title: 'Installing Codewind for IntelliJ'
-        url: mdt-intellij-getting-started.html
+        url: intellij-getting-started.html
 
 - title: 'Using Codewind remotely'
   children:

--- a/docs/_documentations/che-codechange.md
+++ b/docs/_documentations/che-codechange.md
@@ -4,7 +4,7 @@ title: Making a code change with Codewind for Eclipse Che
 description: Making a code change with Codewind for Eclipse Che
 keywords: build, deploy, develop, public cloud, services, command line, cli, command, start, stop, update, open, delete, options, operation, devops
 duration: 1 minute
-permalink: mdt-che-codechange
+permalink: che-codechange
 type: document
 ---
 

--- a/docs/_documentations/che-createcodewindworkspace.md
+++ b/docs/_documentations/che-createcodewindworkspace.md
@@ -4,7 +4,7 @@ title: Creating a Codewind workspace in Che
 description: Creating a Codewind workspace in Che
 keywords: build, deploy, install, installing, installation, chart, Helm, develop, cloud, public cloud, services, command line, cli, command, start, stop, update, open, delete, options, operation, devops
 duration: 1 minute
-permalink: mdt-che-createcodewindworkspace
+permalink: che-createcodewindworkspace
 type: document
 ---
 
@@ -22,4 +22,4 @@ Codewind includes a ready-to-use devfile with its plug-ins.
 
 For more sample devfiles, see [`codewind-templates/devfiles/`](https://github.com/kabanero-io/codewind-templates/tree/master/devfiles).
 
-Next step: [Setup Tekton Pipelines](mdt-che-tektonpipelines.html)
+Next step: [Setup Tekton Pipelines](che-tektonpipelines.html)

--- a/docs/_documentations/che-createfirstproject.md
+++ b/docs/_documentations/che-createfirstproject.md
@@ -4,7 +4,7 @@ title: Creating your first project with Codewind for Eclipse Che
 description: Creating your first project with Codewind for Eclipse Che
 keywords: build, deploy, install, installing, installation, chart, develop, cloud, public cloud, services, command line, cli, command, start, stop, update, open, delete, options, operation, devops
 duration: 1 minute
-permalink: mdt-che-createfirstproject
+permalink: che-createfirstproject
 type: document
 ---
 
@@ -27,4 +27,4 @@ The Codewind Project Explorer view shows two statuses.
 2. After the application is built and deployed, the appliction status changes to **Starting**.
 3. When the application is running, the application status changes to **Running**.
 
-Next step: [Making a code change with Codewind for Eclipse Che](mdt-che-codechange.html)
+Next step: [Making a code change with Codewind for Eclipse Che](che-codechange.html)

--- a/docs/_documentations/che-installinfo.md
+++ b/docs/_documentations/che-installinfo.md
@@ -4,7 +4,7 @@ title: Installing Eclipse Che for Codewind
 description: Installing Eclipse Che for Codewind
 keywords: build, deploy, install, installing, installation, chart, Helm, develop, cloud, public cloud, services, command line, cli, command, start, stop, update, open, delete, options, operation, devops, OpenShift, OKD
 duration: 1 minute
-permalink: mdt-che-installinfo
+permalink: che-installinfo
 type: document
 ---
 
@@ -53,4 +53,4 @@ Codewind needs to run as privileged and as root because it builds container imag
 1. To enable privileged containers, enter `oc adm policy add-scc-to-user privileged system:serviceaccount:<che namespace>:che-workspace`.
 2. To enable containers to run as root, enter `oc adm policy add-scc-to-user anyuid system:serviceaccount:<che namespace>:che-workspace`.
 
-Next step: [Adding registries in Che](mdt-che-setupregistries.html)
+Next step: [Adding registries in Che](che-setupregistries.html)

--- a/docs/_documentations/che-odo-support.md
+++ b/docs/_documentations/che-odo-support.md
@@ -4,10 +4,9 @@ title: OpenShift Do (odo) support in Codewind
 description: OpenShift Do (odo) support in Codewind
 keywords: build, develop, deploy, install, installing, installation, Codewind for Eclipse Che, cloud, public cloud, services, command line, cli, command, devops, OpenShift, OKD, odo
 duration: 1 minute
-permalink: mdt-che-odo-support
+permalink: che-odo-support
 type: document
 order: 1
-parent: mdt-che-installinfo
 ---
 
 # OpenShift Do (odo) support in Codewind
@@ -28,7 +27,7 @@ The Codewind Odo extension provides support for [OpenShift Do (odo)](https://git
 
 ### Prerequisites
 
-- [Install](mdt-che-installinfo.html) Codewind on Che on an OpenShift cluster.
+- [Install](che-installinfo.html) Codewind on Che on an OpenShift cluster.
 
 ### Adding roles to support the extension
 

--- a/docs/_documentations/che-setupregistries.md
+++ b/docs/_documentations/che-setupregistries.md
@@ -4,7 +4,7 @@ title: Adding a container registry in Codewind
 description: Adding a container registry in Codewind
 keywords: container, registry, Che, guidance, image registry, Appsody, Docker, name, push registry, Kubernetes
 duration: 1 minute
-permalink: mdt-che-setupregistries
+permalink: che-setupregistries
 type: document
 ---
 

--- a/docs/_documentations/che-tektonpipelines.md
+++ b/docs/_documentations/che-tektonpipelines.md
@@ -4,7 +4,7 @@ title: Installing Codewind on the Cloud
 description: Installing Codewind on the Cloud
 keywords: build, deploy, install, installing, installation, chart, Helm, develop, cloud, public cloud, services, command line, cli, command, start, stop, update, open, delete, options, operation, devops, OpenShift, OKD
 duration: 1 minute
-permalink: mdt-che-tektonpipelines
+permalink: che-tektonpipelines
 type: document
 order: 20
 parent: root
@@ -21,5 +21,5 @@ oc apply -f setup/install_che/codewind-tektonbinding.yaml
 
 For more information about Tekton, see [Getting started with the Tekton Dashboard Webhooks Extension](https://github.com/tektoncd/experimental/blob/master/webhooks-extension/docs/GettingStarted.md).
 
-Next step: [Adding a container registry in Codewind](mdt-che-setupregistries.html)
+Next step: [Adding a container registry in Codewind](che-setupregistries.html)
 

--- a/docs/_documentations/che-uninstall.md
+++ b/docs/_documentations/che-uninstall.md
@@ -4,10 +4,10 @@ title: Uninstalling Codewind for Eclipse Che
 description: How to uninstall Codewind from Eclipse Che
 keywords: uninstall, remove, delete, tools, eclipse, uninstalling Codewind for Eclipse Che, restart Eclipse
 duration: 1 minute
-permalink: mdt-che-uninstall
+permalink: che-uninstall
 type: document
 order: 70
-parent: mdteclipseoverview
+parent: eclipseoverview
 ---
 
 # Uninstalling Codewind for Eclipse Che

--- a/docs/_documentations/che-usingtheia.md
+++ b/docs/_documentations/che-usingtheia.md
@@ -4,7 +4,7 @@ title: Installing Codewind on the Cloud
 description: Installing Codewind on the Cloud
 keywords: build, deploy, install, installing, installation, chart, Helm, develop, cloud, public cloud, services, command line, cli, command, start, stop, update, open, delete, options, operation, devops, OpenShift, OKD
 duration: 1 minute
-permalink: mdt-che-usingtheia
+permalink: che-usingtheia
 type: document
 order: 20
 parent: root

--- a/docs/_documentations/eclipse-codechange.md
+++ b/docs/_documentations/eclipse-codechange.md
@@ -4,10 +4,10 @@ title: "Making a code change with Eclipse"
 description: "Making a code change with Eclipse"
 keywords: introducing, introduction, overview, tools, get, getting, start, started, install, vscode, visual, studio, code, Codewind for VS Code getting started, VS Code Marketplace, VS Code Extensions view, VS Code workspace,installing Codewind for VS Code
 duration: 1 minute
-permalink: mdt-eclipse-codechange
+permalink: eclipse-codechange
 type: document
 order: 1
-parent: mdt-vsc-overview
+parent: vsc-overview
 ---
 # Making a code change with Eclipse 
 <br/>

--- a/docs/_documentations/eclipse-firstproject.md
+++ b/docs/_documentations/eclipse-firstproject.md
@@ -4,10 +4,9 @@ title: "Creating your first Eclipse Codewind project"
 description: "Creating your first Eclipse Codewind project"
 keywords: introducing, introduction, overview, what is, tools, vscode, visual, studio, code, java, microprofile, spring, node, nodejs, node.js, javascript, Codewind for VS Code, tools, view, debug, integrate, open a shell session, toggle auto build, manually build, scope VS Code workspace, disable, enable, delete
 duration: 1 minute
-permalink: mdt-eclipse-firstproject
+permalink: eclipse-firstproject
 type: document
 order: 2
-parent: mdt-eclipse-overview
 ---
 # Creating your first Eclipse Codewind project
 <br/>
@@ -44,6 +43,6 @@ This icon launches your web browser and displays your application.
 
 Congratulations, you have created your first application on Codewind.
 
-Next step: [Making a code change](mdt-eclipse-codechange.html)
+Next step: [Making a code change](eclipse-codechange.html)
 
 

--- a/docs/_documentations/eclipse-getting-started.md
+++ b/docs/_documentations/eclipse-getting-started.md
@@ -4,10 +4,9 @@ title: "Installing Codewind for Eclipse"
 description: "Installing Codewind for Eclipse"
 keywords: introducing, introduction, overview, what is, tools, eclipse, getting started, Codewind for Eclipse, work within Eclipse
 duration: 1 minute
-permalink: mdt-eclipse-getting-started
+permalink: eclipse-getting-started
 type: document
 order: 5
-parent: mdteclipseoverview
 ---
 
 # Installing Codewind for Eclipse
@@ -39,4 +38,4 @@ To install Codewind for Eclipse, complete the following steps:
 
 ![image of Codewind once installed](dist/images/eclipseinstall2.png){:width="800px"}
 
-Next step: [Create your first project](mdt-eclipse-firstproject.html)
+Next step: [Create your first project](eclipse-firstproject.html)

--- a/docs/_documentations/eclipse-uninstall.md
+++ b/docs/_documentations/eclipse-uninstall.md
@@ -4,10 +4,9 @@ title: Uninstalling Codewind for Eclipse
 description: How to uninstall Codewind from Eclipse
 keywords: uninstall, remove, delete, tools, eclipse, uninstalling Codewind for Eclipse, restart Eclipse
 duration: 1 minute
-permalink: mdteclipseuninstall
+permalink: eclipse-uninstall
 type: document
 order: 70
-parent: mdteclipseoverview
 ---
 
 # Uninstalling Codewind from Eclipse

--- a/docs/_documentations/gettingstarted.md
+++ b/docs/_documentations/gettingstarted.md
@@ -20,9 +20,9 @@ type: document
       <span class=" cs-gettingstarted-mobile-title cw-getting-started-text">Cloud &nbsp;</span>
       </div>
       <div class="cw-gettingstarted-card">
-        <a href="mdt-che-installinfo.html"><img alt="Install on cloud"  title="Install on cloud"  src="images/card/che.svg"/></a>
+        <a href="che-installinfo.html"><img alt="Install on cloud"  title="Install on cloud"  src="images/card/che.svg"/></a>
       	<div class="cw-gettingstarted-card-link-container">
-      		<a class="cw-gettingstarted-card-link" href="mdt-che-installinfo.html">Codewind for Eclipse Che</a>
+      		<a class="cw-gettingstarted-card-link" href="che-installinfo.html">Codewind for Eclipse Che</a>
       	</div>
       </div>
     </div>
@@ -32,9 +32,9 @@ type: document
       <span class="cs-gettingstarted-mobile-title cw-getting-started-text">Local &nbsp;</span>
       </div>
       <div class="cw-gettingstarted-card">
-        <a href="mdt-vsc-getting-started.html"><img alt="VSCode getting started"  title="VSCode getting started"  src="images/card/vscode.svg"/></a>
+        <a href="vsc-getting-started.html"><img alt="VSCode getting started"  title="VSCode getting started"  src="images/card/vscode.svg"/></a>
       	<div class="cw-gettingstarted-card-link-container">
-      		<a class="cw-gettingstarted-card-link" href="mdt-vsc-getting-started.html">Codewind for VS Code</a>
+      		<a class="cw-gettingstarted-card-link" href="vsc-getting-started.html">Codewind for VS Code</a>
       	</div>
       </div>
     </div>
@@ -44,9 +44,9 @@ type: document
       	<span class="cs-gettingstarted-mobile-title cw-getting-started-text">Local &nbsp;</span>
       	</div>
       <div class="cw-gettingstarted-card">
-        <a href="mdt-eclipse-getting-started.html"><img alt="Eclipse che getting started"  title="Eclipse che getting started"  src="images/card/eclipse.svg"/></a>
+        <a href="eclipse-getting-started.html"><img alt="Eclipse che getting started"  title="Eclipse che getting started"  src="images/card/eclipse.svg"/></a>
       	<div class="cw-gettingstarted-card-link-container">
-      		<a class="cw-gettingstarted-card-link" href="mdt-eclipse-getting-started.html">Codewind for Eclipse</a>
+      		<a class="cw-gettingstarted-card-link" href="eclipse-getting-started.html">Codewind for Eclipse</a>
       	</div>
       </div>
     </div>

--- a/docs/_documentations/intellij-getting-started.md
+++ b/docs/_documentations/intellij-getting-started.md
@@ -4,7 +4,7 @@ title: Installing Codewind on IntelliJ
 description: Installing Codewind on IntelliJ
 keywords: install, installing, IntelliJ, Eclipse, Codewind, IDE, plugin, plug-in, settings, creating, project, projects, template, code change, edit, edits, application, removing
 duration: 1 minute
-permalink: mdt-intellij-getting-started
+permalink: intellij-getting-started
 type: document
 ---
 

--- a/docs/_documentations/overview.md
+++ b/docs/_documentations/overview.md
@@ -49,7 +49,7 @@ Codewind improves your inner loop experience, enabling you to create a microserv
 
 ### What Integrated Development Environments (IDEs) does Codewind support?
 
-Codewind is available as a desktop IDE extension for [**VS Code**](https://marketplace.visualstudio.com/items?itemName=IBM.codewind) and [**Eclipse**](https://marketplace.eclipse.org/content/codewind) and as a cloud-based IDE extension for [**Eclipse Che**](https://www.eclipse.org/codewind/mdt-che-installinfo.html).
+Codewind is available as a desktop IDE extension for [**VS Code**](https://marketplace.visualstudio.com/items?itemName=IBM.codewind) and [**Eclipse**](https://marketplace.eclipse.org/content/codewind) and as a cloud-based IDE extension for [**Eclipse Che**](https://www.eclipse.org/codewind/che-installinfo.html).
 
 ### What cloud native technology does Codewind support?
 Codewind supports [Kubernetes](https://kubernetes.io/) and [OpenShift](https://www.openshift.com/) for container orchestration. 

--- a/docs/_documentations/remote-jane-overview.md
+++ b/docs/_documentations/remote-jane-overview.md
@@ -10,7 +10,7 @@ type: document
 
 # Using Codewind remotely
 
-Codewind can be used in one of three ways - locally, [hosted](./mdt-che-installinfo.html) as an application on a cloud, or remotely. By using Codewind remotely, you can develop your code locally, but build and run your application in the cloud. Remote use of Codewind frees up your desktop resources, using the cloud's resources to build and run applications. 
+Codewind can be used in one of three ways - locally, [hosted](./che-installinfo.html) as an application on a cloud, or remotely. By using Codewind remotely, you can develop your code locally, but build and run your application in the cloud. Remote use of Codewind frees up your desktop resources, using the cloud's resources to build and run applications. 
 
 # What you will learn
 
@@ -31,7 +31,7 @@ Once you have connected your local Codewind to Codewind in the cloud, you will l
 Before deploying Codewind to the cloud, you must:
 
 1. **Install your preferred IDE on your local machine.** 
-For more information about installing Eclipse, see [Getting started with Codewind for Eclipse](mdteclipsegettingstarted.html), or for more information about installing VS Code, see [Getting started with Codewind for VS Code](mdt-vsc-getting-started.html).
+For more information about installing Eclipse, see [Getting started with Codewind for Eclipse](eclipse-getting-started.html), or for more information about installing VS Code, see [Getting started with Codewind for VS Code](vsc-getting-started.html).
 
 2. **Have access to a keyring** A keyring is a software application designed to store security credentials, such as usernames, passwords, and keys, together with a small amount of relevant metadata. Examples of a keyring are Keychain on macOS, Credential Manager on Windows, and Secret Service on Linux.
 

--- a/docs/_documentations/remote-overview.md
+++ b/docs/_documentations/remote-overview.md
@@ -10,7 +10,7 @@ type: document
 
 # Deploying Codewind remotely overview
 
-Codewind can be used in one of three ways - locally, [hosted](./mdt-che-installinfo.html) as an application on a cloud, or remotely. By deploying Codewind remotely, developers can develop their code locally, but build and run your application in the cloud. Remote use of Codewind frees up desktop resources, using the cloud's resources to build and run applications. 
+Codewind can be used in one of three ways - locally, [hosted](./che-installinfo.html) as an application on a cloud, or remotely. By deploying Codewind remotely, developers can develop their code locally, but build and run your application in the cloud. Remote use of Codewind frees up desktop resources, using the cloud's resources to build and run applications. 
 
 To learn how to use Codewind once it has been deployed remotely, see [Using Codewind remotely](remote-jane-overview.html).
 
@@ -37,7 +37,7 @@ Before deploying Codewind to the cloud, you must:
 ## Planning your remote deployment - Codewind and Authentication Services
 
 1. **Install your preferred IDE on your local machine.** 
-For more information about installing Eclipse, see [Getting started with Codewind for Eclipse](mdteclipsegettingstarted.html), or for more information about installing VS Code, see [Getting started with Codewind for VS Code](mdt-vsc-getting-started.html).
+For more information about installing Eclipse, see [Getting started with Codewind for Eclipse](eclipse-getting-started.html), or for more information about installing VS Code, see [Getting started with Codewind for VS Code](vsc-getting-started.html).
 
 2. **Ensure that you have access to the Codewind CLI `cwctl`.** To access the Codewind CLI, open a terminal window and navigate to the following hidden folder: `~/.codewind/<version>`. On Windows, navigate to the following folder: `%SystemDrive%\Users\<username>\.codewind\<version>`.
 

--- a/docs/_documentations/remotedeploy-eclipse.md
+++ b/docs/_documentations/remotedeploy-eclipse.md
@@ -12,7 +12,7 @@ order: 2
 
 # Connecting Eclipse to your remote Codewind instance
 
-Ensure you have [satisfied all prequisites](./remote-deploy-jane.html). 
+Ensure you have [satisfied all prequisites](./remote-jane-overview.html). 
 
 # Objectives
 

--- a/docs/_documentations/remotedeploy-vscode.md
+++ b/docs/_documentations/remotedeploy-vscode.md
@@ -12,7 +12,7 @@ order: 2
 
 # Connecting VS Code to your remote Codewind instance
 
-Ensure you have [satisfied all prequisites](./remote-deploy-jane.html). 
+Ensure you have [satisfied all prequisites](./remote-jane-overview.html). 
 
 # Objectives
 

--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -538,7 +538,7 @@ For Codewind to work with an Appsody stack image on a private Docker registry, t
 - **Note:** When you view the application log, you might see failures to pull the image during a rebuild. However, Codewind is taking the cached container image from your local machine. If you ever delete that image, you need to pull the image again. You can either create another project from the same stack or manually call a `docker pull` with the required image.
 
 **Remote scenario**
-Follow the instructions in [Adding a container registry in Codewind](mdt-che-setupregistries.html).
+Follow the instructions in [Adding a container registry in Codewind](che-setupregistries.html).
 
 ***
 # OpenShift Do (odo) with Codewind

--- a/docs/_documentations/vsc-codechange.md
+++ b/docs/_documentations/vsc-codechange.md
@@ -7,7 +7,6 @@ duration: 1 minute
 permalink: vsc-codechange
 type: document
 order: 1
-parent: mdt-vsc-overview
 ---
 # Making a code change with VS Code
 <br/>

--- a/docs/_documentations/vsc-commands-overview.md
+++ b/docs/_documentations/vsc-commands-overview.md
@@ -4,10 +4,10 @@ title: "Commands overview: Tools for VS Code"
 description: "Commands Overview: Tools for VS Code"
 keywords: overview, tools, vscode, visual, studio, code, commands, Codewind for VS Code commands overview, connection commands, project commands, restart, debug
 duration: 1 minute
-permalink: mdt-vsc-commands-overview
+permalink: vsc-commands-overview
 type: document
 order: 3
-parent: mdt-vsc-overview
+parent: vsc-overview
 ---
 
 # Commands overview: Codewind for VS Code
@@ -17,5 +17,5 @@ All commands provided by this extension are available in the [Command Palette](h
 Some commands apply to individual projects, others like **Start** and **Stop** apply to Codewind as a whole. Run a command from the Command Palette to view a list projects on which you can run the command. Additionally, the list might be filtered depending on the command. For example, the **Disable project** command runs only on projects that are **Enabled**.
 
 Commands are separated into categories. See the following pages:
-- [Project commands](mdt-vsc-commands-project.html)
-- [Restart and debug](mdt-vsc-commands-restart-and-debug.html)
+- [Project commands](vsc-commands-project.html)
+- [Restart and debug](vsc-commands-restart-and-debug.html)

--- a/docs/_documentations/vsc-commands-project.md
+++ b/docs/_documentations/vsc-commands-project.md
@@ -4,10 +4,9 @@ title: "Project commands: Tools for VS Code"
 description: "Project commands: Tools for VS Code"
 keywords: tools, vscode, visual, studio, code, commands, project, Codewind Developer Tools for VS Code project commands overview, connection commands, restart, debug
 duration: 1 minute
-permalink: mdt-vsc-commands-project
+permalink: vsc-commands-project
 type: document
 order: 2
-parent: mdt-vsc-commands-overview
 ---
 
 # Project commands: Codewind for VS Code
@@ -129,6 +128,6 @@ The list of supported project settings are:
 
 ***
 
-[Next: Restart and debug](mdt-vsc-commands-restart-and-debug.html)
+[Next: Restart and debug](vsc-commands-restart-and-debug.html)
 
-[Troubleshooting](mdt-vsc-troubleshooting.html)
+[Troubleshooting](troubleshooting.html)

--- a/docs/_documentations/vsc-firstproject.md
+++ b/docs/_documentations/vsc-firstproject.md
@@ -4,10 +4,9 @@ title: "Creating your first VS Code Codewind project"
 description: "Creating your first VS Code Codewind project"
 keywords: introducing, introduction, overview, what is, tools, vscode, visual, studio, code, java, microprofile, spring, node, nodejs, node.js, javascript, Codewind for VS Code, tools, view, debug, integrate, open a shell session, toggle auto build, manually build, scope VS Code workspace, disable, enable, delete
 duration: 1 minute
-permalink: mdt-vsc-firstproject
+permalink: vsc-firstproject
 type: document
 order: 2
-parent: mdt-vsc-overview
 ---
 # Creating your first VS Code Codewind project
 <br/>

--- a/docs/_documentations/vsc-getting-started.md
+++ b/docs/_documentations/vsc-getting-started.md
@@ -4,10 +4,9 @@ title: "Installing Codewind for VS Code"
 description: "Installing Codewind for VS Code"
 keywords: introducing, introduction, overview, tools, get, getting, start, started, install, vscode, visual, studio, code, Codewind for VS Code getting started, VS Code Marketplace, VS Code Extensions view, VS Code workspace,installing Codewind for VS Code
 duration: 1 minute
-permalink: mdt-vsc-getting-started
+permalink: vsc-getting-started
 type: document
 order: 1
-parent: mdt-vsc-overview
 ---
 
 # Installing Codewind for VS Code
@@ -27,4 +26,4 @@ parent: mdt-vsc-overview
    
 ![image of Codewind once installed](dist/images/installed.png){:width="800px"}
 
-Next step: [Create your first project](mdt-vsc-firstproject.html)
+Next step: [Create your first project](vsc-firstproject.html)

--- a/docs/_documentations/vsc-installinfo.md
+++ b/docs/_documentations/vsc-installinfo.md
@@ -4,7 +4,7 @@ title: Installing Codewind for VS Code
 description: Installing Codewind for VS Code
 keywords: install, installing, add, adding, tools, VS Code, Eclipse, installing Codewind for VS Code
 duration: 1 minute
-permalink: mdt-vsc-installinfo
+permalink: vsc-installinfo
 type: document
 order: 
 parent: 
@@ -40,7 +40,7 @@ Update your Codewind plug-in without uninstalling the extension.
 5. Wait for the Codewind installation to complete. Codewind starts and is ready to use.
 
 ## Removing containers and images
-To remove Codewind, see [Uninstalling Codewind from VS Code](mdt-vsc-uninstall.html).
+To remove Codewind, see [Uninstalling Codewind from VS Code](vsc-uninstall.html).
 
 ## Troubleshooting
 
@@ -48,6 +48,6 @@ To remove Codewind, see [Uninstalling Codewind from VS Code](mdt-vsc-uninstall.h
 If you don't click **Install** when the **Install** prompt first appears, you can access the notification again. Go to the **Explorer** view, hover the cursor over **Codewind**, and click the switch so that it changes to the **On** position. The **Install** prompt appears.
 
 #### Resetting the installation
-To reset the installation, [uninstall Codewind](mdt-vsc-uninstall.html) and install it again.
+To reset the installation, [uninstall Codewind](vsc-uninstall.html) and install it again.
 
 For more information about troubleshooting Codewind, see the [Troubleshooting page](troubleshooting.html).

--- a/docs/_documentations/vsc-nodejsprofiling.md
+++ b/docs/_documentations/vsc-nodejsprofiling.md
@@ -4,7 +4,7 @@ title: Installing and running the Codewind language server for Node.js profiling
 description: Installing and running the Codewind language server for Node.js profiling
 keywords: Node.js, Codewind, server, language, languages, code, code highlighting, highlighting, profiling, Visual Studio Code, VS Code, JavaScript
 duration: 1 minute
-permalink: mdt-vsc-nodejsprofiling
+permalink: vsc-nodejsprofiling
 type: document
 ---
 
@@ -12,7 +12,7 @@ type: document
 The Codewind language server for Node.js profiling annotates your Node.js code with code highlighting. Code highlighting uses the profiling data gathered through Codewind load testing to highlight and show the relative time that is spent in JavaScript functions.
 
 ## Running the extension with Visual Studio Code (VS Code)
-1. Open a local project that you created with [Codewind](mdt-vsc-getting-started.html) and profiled by using the [performance test](guide_performance.html) feature. Opening the project creates profiling data in a `load-test/[datestamp]/profiling.json` file in your Codewind project.
+1. Open a local project that you created with [Codewind](vsc-getting-started.html) and profiled by using the [performance test](guide_performance.html) feature. Opening the project creates profiling data in a `load-test/[datestamp]/profiling.json` file in your Codewind project.
 2. In VS Code, open a JavaScript file in your project. The extension highlights any lines that it finds in the profiling data and annotates them to show how often they were seen and where they were called from.
 
 ## Developing the extension with VS Code

--- a/docs/_documentations/vsc-tutorial.md
+++ b/docs/_documentations/vsc-tutorial.md
@@ -4,28 +4,28 @@ title: "Tutorial: Tools for VS Code"
 description: "Tutorial: Tools for VS Code"
 keywords: tools, vscode, visual, studio, code, example, how, use, using, tutorial, Codewind for VS Code tutorial
 duration: 1 minute
-permalink: mdt-vsc-tutorial
+permalink: vsc-tutorial
 type: document
 order: 2
-parent: mdt-vsc-overview
+parent: vsc-overview
 ---
 
 # Tutorial: Codewind for VS Code
 Follow this example workflow to use the tools for VS Code to develop a Node.js project. All the features demonstrated in this tutorial are also available for Microprofile and Spring projects.
 
-For more detail on any of the commands, see the [commands overview](mdt-vsc-commands-overview.html).
+For more detail on any of the commands, see the [commands overview](vsc-commands-overview.html).
 
-1. First, ensure that Codewind is installed and running. For more information, see the [Getting started: Codewind for VS Code](mdt-vsc-getting-started.html) page. Proceed after your projects appear with the **Codewind view**.
+1. First, ensure that Codewind is installed and running. For more information, see the [Getting started: Codewind for VS Code](vsc-getting-started.html) page. Proceed after your projects appear with the **Codewind view**.
 2. Create a Node.js project in Codewind. Skip this step if a Node.js project already exists. This tutorial assumes that your project is called *nodeproject*.
     - Right-click the **Projects (Local)** item in the Codewind tree and select **Create new project**.
     - In the **Command Palette**, select **Node.js Template** and press **Enter**.
     - In the **Command Palette**, type a name for the project and press **Enter**.
 3. Make the new project your workspace folder. This project is the only project that you need to work on for this tutorial.
-    - Right-click the project and select [Open Folder as Workspace](mdt-vsc-commands-project.html#open-folder-as-workspace). VS Code restarts with the selected project folder as the workspace folder.
+    - Right-click the project and select [Open Folder as Workspace](vsc-commands-project.html#open-folder-as-workspace). VS Code restarts with the selected project folder as the workspace folder.
 4. Open the **Project Overview** page to view project information.
-    - Right-click the project and select [Show Project Overview](mdt-vsc-commands-project.html#show-project-overview).
+    - Right-click the project and select [Show Project Overview](vsc-commands-project.html#show-project-overview).
 5. To view the project standard output and error as you develop it, open the application logs.
-    - Right-click the project and select [Show Application Log](mdt-vsc-commands-project.html#logs). The log appears in the **Output** view.
+    - Right-click the project and select [Show Application Log](vsc-commands-project.html#logs). The log appears in the **Output** view.
     - Node.js projects do not have build logs, but if you work on some other types of projects, you can also view the build logs.
 6. Open a file to edit. For example, modify the `health` endpoint of the default Node.js project.
     - Open a Javascript file, such as `nodeproject/server/routers/health.js`.
@@ -42,16 +42,16 @@ For more detail on any of the commands, see the [commands overview](mdt-vsc-comm
     - At this point, your VS Code should look similar to the following example:
     <br>![Editing nodeproject](dist/images/cdt-vsc/tutorial-1.png)
 7. To make sure your code change was picked up, test your new endpoint.
-    - Right-click the project and select [Open App](mdt-vsc-commands-project.html#open-app). The project root endpoint opens in the browser, and the **IBM Cloud Starter** page appears.
+    - Right-click the project and select [Open App](vsc-commands-project.html#open-app). The project root endpoint opens in the browser, and the **IBM Cloud Starter** page appears.
     - Navigate to the new endpoint. If you copied the previous snippet, add `/health/test/` to the URL.
     - See the new response:<br>
     <br>![New endpoint response](dist/images/cdt-vsc/tutorial-2.png)
 8. You can debug your application within the container. To debug a containerized project, restart it in **Debug** mode.
-    - Right-click the project and select [Restart in Debug Mode](mdt-vsc-commands-restart-and-debug.html#restart).
+    - Right-click the project and select [Restart in Debug Mode](vsc-commands-restart-and-debug.html#restart).
     - The project restarts into the **Debugging** state.
     - A debug launch configuration is created in `nodeproject/.vscode/launch.json`.
     - The debugger attaches, and VS Code opens the **Debug** view.
-    - You can detach and [reattach the debugger](mdt-vsc-commands-restart-and-debug.html#attach-debugger) at any time, as long as the project is still in **Debug** mode.
+    - You can detach and [reattach the debugger](vsc-commands-restart-and-debug.html#attach-debugger) at any time, as long as the project is still in **Debug** mode.
 9. All of the VS Code debug functionality is now available.
     - If your code matches the screenshot, set a breakpoint at line 13 in `health.js`.
     - Refresh the new endpoint page that you opened in step 7 so that a new request is made, and the breakpoint gets hit.

--- a/docs/_documentations/vsc-uninstall.md
+++ b/docs/_documentations/vsc-uninstall.md
@@ -4,7 +4,7 @@ title: Uninstalling Codewind for VS Code
 description: Uninstalling Codewind for VS Code
 keywords: uninstall, remove, delete, tools, eclipse, uninstalling Codewind for VS Code
 duration: 1 minute
-permalink: mdt-vsc-uninstall
+permalink: vsc-uninstall
 type: document
 ---
 

--- a/docs/_news/news06.md
+++ b/docs/_news/news06.md
@@ -40,6 +40,6 @@ The information in the **VS Code** section also applies to Eclipse but with thes
 - Templates are improved with added details about what a template is. Information is also included for managing templates, working with default templates, and adding your own templates. For more information, see [Working with templates](workingwithtemplates.html).
 
 #### VS Code output view
-- New to VS Code is the Codewind output stream, which logs `cwctl` commands and their output. In addition to providing status on all of your `cwctl` commands, it also helps you to debug unusual problems, especially when you start Codewind. For more information, see [Troubleshooting](mdt-vsc-troubleshooting.html).<br>
+- New to VS Code is the Codewind output stream, which logs `cwctl` commands and their output. In addition to providing status on all of your `cwctl` commands, it also helps you to debug unusual problems, especially when you start Codewind. For more information, see [Troubleshooting](troubleshooting.html).<br>
 
 ![Image of VS Code output](dist/images/cdt-vsc/output_view.png)<br>

--- a/docs/_news/news07.md
+++ b/docs/_news/news07.md
@@ -26,7 +26,7 @@ Curious? [Learn more](remote-overview.html)!
 
 **OpenShift Do (odo)**
 - You can now easily import existing projects into Codewind and [use odo](https://github.com/eclipse/codewind/issues/1115) to build and deploy projects to your OpenShift or OKD cluster.
-- Codewind now [supports Java templates](https://github.com/eclipse/codewind/issues/450), and Java projects can build and deploy after they have been [configured](mdt-che-odo-support.html).
+- Codewind now [supports Java templates](https://github.com/eclipse/codewind/issues/450), and Java projects can build and deploy after they have been [configured](che-odo-support.html).
 
 **Docker**
 - You can now specify any [Docker registry secret](https://github.com/eclipse/codewind/issues/1178) required by Codewind within the Codewind extension for the editor.

--- a/docs/_news/news09.md
+++ b/docs/_news/news09.md
@@ -15,7 +15,7 @@ Introducing the tech preview of Codewind on the IntelliJ IDE! We want to make ou
 
 ![](images/imagesfornews/intelliJ-techpreview.gif){:width="800"}
 
-Try it out [here](mdt-intellij-getting-started.html).
+Try it out [here](intellij-getting-started.html).
 
 **IDEs (Both Eclipse and VS Code)**
 - Detailed application status notifications provide a [link to documentation if a problem is encountered](https://github.com/eclipse/codewind/issues/1812).


### PR DESCRIPTION
Signed-off-by: micgibso <MICGIBSO@uk.ibm.com>

PR for https://github.com/eclipse/codewind/issues/2307

Removed all occurrences of `mdt-` from the doc source by:
Opening all `mdt-` prefixed files:
- Changed the `mdt-` permalink
- Searching for any occurrences of `mdt-` in the file content and changing when found

Updated the TOC removing `mdt-`
Renamed `mdt-` files
Updated the News and any other misc files with links to `mdt-` files. 

Tested the TOC and links, all good. 