### PR TITLE
Fixing formatting in Eclipse doc

### DIFF
--- a/docs/_documentations/eclipse-getting-started.md
+++ b/docs/_documentations/eclipse-getting-started.md
@@ -10,16 +10,16 @@ order: 5
 ---
 
 # Installing Codewind for Eclipse
-<br/>
+
 Install Codewind for Eclipse to develop your containerized projects from within Eclipse.  
 
 To install Codewind for Eclipse, complete the following steps:
 
-1\. Download and install the latest [Eclipse IDE for Enterprise Java Developers](https://www.eclipse.org/downloads/packages/) or use an existing installation.
+1. Download and install the latest [Eclipse IDE for Enterprise Java Developers](https://www.eclipse.org/downloads/packages/) or use an existing installation.
     - Install Eclipse IDE Version 2019-09 R (4.13.0) or later to avoid [Bug 541220](https://bugs.eclipse.org/bugs/show_bug.cgi?id=541220).
     - **Note:** the earliest supported version of the Eclipse IDE is Version 2019-03 (4.11).
-2\. Install [Docker](https://docs.docker.com/install/) 17.06 or later. If you use Linux, you must also install [Docker Compose](https://docs.docker.com/compose/install/).
-3\. Install [Codewind from Eclipse Marketplace](https://marketplace.eclipse.org/content/codewind).
+2. Install [Docker](https://docs.docker.com/install/) 17.06 or later. If you use Linux, you must also install [Docker Compose](https://docs.docker.com/compose/install/).
+3. Install [Codewind from Eclipse Marketplace](https://marketplace.eclipse.org/content/codewind).
     - [![Drag to your running Eclipse workspace. ](https://marketplace.eclipse.org/sites/all/themes/solstice/public/images/marketplace/btn-install.png)](http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=4638524 "Drag to your running Eclipse* workspace. *Requires Eclipse Marketplace Client") Drag this install button to your running Eclipse workspace.
        - **Note:** You must have the Eclipse Marketplace Client.
     - To install from the Eclipse IDE, complete the following steps:
@@ -28,9 +28,9 @@ To install Codewind for Eclipse, complete the following steps:
         3. Click the **Install** button.
         4. Finish the wizard and accept licenses as needed.
         5. When the installation is complete, restart Eclipse.
-4\. Open the Codewind view. 
+4. Open the Codewind view. 
     - Navigate to **Window**>**Show View**>**Other...**>**Codewind**>**Codewind Explorer**
-5\. Codewind requires the installation of additional Docker images to run.  Double-click the **Codewind** item in the Codewind Explorer view to complete the installation. The installation might take a few minutes to complete.
+5. Codewind requires the installation of additional Docker images to run.  Double-click the **Codewind** item in the Codewind Explorer view to complete the installation. The installation might take a few minutes to complete.
    
 ![image of Codewind once installed](dist/images/eclipseinstall1.png){:width="800px"}
 


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

PR to replace https://github.com/eclipse/codewind-docs/pull/431

**Screenshot of file with line breaks added:**
<img width="1240" alt="Screen Shot 2020-02-27 at 3 20 36 PM" src="https://user-images.githubusercontent.com/21180723/75483556-16fdd100-5975-11ea-8555-cb470d10c656.png">
- Under step 3, substeps 1 through 5 are not indented.
- Some bullet points, such as the **Note:** and Install button, are not on separate lines. 

**Screenshot of file with `\` characters removed:**
<img width="871" alt="Screen Shot 2020-02-27 at 3 19 37 PM" src="https://user-images.githubusercontent.com/21180723/75483644-4ad8f680-5975-11ea-9c10-5d985a79f0e0.png">
- Step 6 is not aligned with main steps 1 through 5, but at least all other formatting is intact.