### PR TITLE
Update remotedeploy-eclipse text to match Codewind IDE for Eclipse

### DIFF
--- a/docs/_documentations/remotedeploy-eclipse.md
+++ b/docs/_documentations/remotedeploy-eclipse.md
@@ -18,14 +18,18 @@ Ensure you have [satisfied all prequisites](./remote-codewind-overview.html).
 
 In this topic you will:
 
-1. connect Codewind on Eclipse to the remote instance of Codewind in the cloud. 
+1. Connect Codewind on Eclipse to the remote instance of Codewind in the cloud
 
 2. Add a deployment registry
+
+3. Create a new project
+
+4. Copy an existing project to your remote connection
 
 # 1. Connect your IDE's Codewind extension to your remote instance of Codewind
 
 
-1\. Locate the Codewind view in Eclipse and click the cloud icon to launch the new connection wizard:
+1\. Locate the Codewind Explorer view in Eclipse and click the cloud icon to launch the new connection wizard:
 
 ![New Connection](./images/remoteeclipse/newConnection.png)
 
@@ -41,13 +45,13 @@ The IDE and Codewind are connected.
 
 # 2. Add a deployment registry
 
-Before projects can be deployed on Kubernetes, you must specify a Docker registry. This example uses Docker Hub. 
+Before projects can be deployed on Kubernetes, you must specify a Docker push registry. This example uses Docker Hub. 
 
-1\. If it's not already open, navigate to the connection details page, right-click the deployment, and select `Manage Image Registries`:
+1\. Right-click on your remote connection in the Codewind Explorer view, and select `Manage Image Registries`:
 
 ![Docker Registry](./images/remoteeclipse/connectionSettings.png)
 
-2\. Locate and click `Click Add to create a new registry`:
+2\. Locate and click `Add` to create a new registry:
 
 ![Open Registry Manager](./images/remoteeclipse/registryManager.png)
 
@@ -64,7 +68,7 @@ The connection is tested to validate your credentials, and these are then stored
 
 ## Create a new project
 
-1\. Navigate to the Codewind panel, right-click the deployment, and then click `create new project`:
+1\. In the Codewind Explorer view, right-click your remote connection, and select `Create New Project`:
 
 ![Adding new remote project](./images/remoteeclipse/newProject.png)
 
@@ -76,7 +80,7 @@ The connection is tested to validate your credentials, and these are then stored
 
 The following procedure copies an existing local project `myFirstNodeProject` over to the remote Codewind deployment:
 
-1\. Right-click the remote deployment and click the `Add existing project button`:
+1\. Right-click your remote connection in the Codewind Explorer view and select `Add Existing Project`:
 
 ![Add existing project](./images/remoteeclipse/addExistingProject.png)
 
@@ -84,13 +88,13 @@ The following procedure copies an existing local project `myFirstNodeProject` ov
 
 ![Add to Codewind](./images/remoteeclipse/existingProject.png)
 
-3\. Codewind prompts you to confirm the project type identified as `NodeJS`:
+3\. Codewind prompts you to confirm the project type identified as `Node.js`:
 
 ![Confirm Project Type](./images/remoteeclipse/confirmProjectType.png)
 
-4\. Click `Next`.
+4\. Click `Finish`.
 
-The project files are copied over to the Codewind server and the new `myFirstNodeProject` appears in the Codewind panel. Codewind builds your application code and Docker image, and moments later, the project image is uploaded to Docker Hub and used by your cloud deployment to provision a new pod:
+The project files are copied over to the Codewind server and the new `myFirstNodeProject` appears under your remote connection. Codewind builds your application code and Docker image, and moments later, the project image is uploaded to Docker Hub and used by your cloud deployment to provision a new pod:
 
 ![Build Success](./images/remoteeclipse/buildSuccess.png)
 
@@ -98,6 +102,6 @@ The project files are copied over to the Codewind server and the new `myFirstNod
 
 # Next Steps
 
-You have now finshed configuring Codewind to be used remotely. 
+You have now finished configuring Codewind to be used remotely. 
 
 In the next topic, you will learn how to [use Codewind remotely to build and run projects in your cloud](./remotedeploy-projects.html).

--- a/docs/_documentations/remotedeploy-eclipse.md
+++ b/docs/_documentations/remotedeploy-eclipse.md
@@ -66,7 +66,7 @@ Before projects can be deployed on Kubernetes, you must specify a Docker push re
 
 The connection is tested to validate your credentials, and these are then stored in a Kubernetes secret within the Codewind service.
 
-## Create a new project
+# 3. Create a new project
 
 1\. In the Codewind Explorer view, right-click your remote connection, and select `Create New Project`:
 
@@ -76,7 +76,7 @@ The connection is tested to validate your credentials, and these are then stored
 
 ![Adding new remote project](./images/remoteeclipse/runningProject.png)
 
-## Copying an existing local project to the cloud
+# 4. Copying an existing local project to the cloud
 
 The following procedure copies an existing local project `myFirstNodeProject` over to the remote Codewind deployment:
 


### PR DESCRIPTION
Various updates to the text where it did not match the actual Codewind IDE for Eclipse.