### PR TITLE
[Not for 0.10.0/Review required] Adding remote deploy info to existing files

### DIFF
--- a/docs/_documentations/remotedeploy-eclipse.md
+++ b/docs/_documentations/remotedeploy-eclipse.md
@@ -12,22 +12,17 @@ order: 2
 
 # Connecting Eclipse to remote Codewind
 
-Ensure you have [satisfied all prequisites](./remote-codewind-overview.html). 
+Complete the [prequisites](./remote-codewind-overview.html). 
 
-# Objectives
+## Objectives
 
 In this topic you will:
-
 1. Connect Codewind on Eclipse to the remote instance of Codewind in the cloud.
-
-
-2. Add a deployment registry.
-
+2. Add an image registry.
 3. Create a new project.
-
 4. Copy an existing project to your remote connection.
 
-# 1. Connect your IDE's Codewind extension to your remote instance of Codewind
+## 1. Connect your IDE's Codewind extension to your remote instance of Codewind.
 
 1\. Locate the Codewind Explorer view in Eclipse and click the cloud icon to launch the new connection wizard:
 
@@ -43,14 +38,13 @@ The IDE validates the connection and adds it to the Codewind panel:
 
 The IDE and Codewind are connected.
 
-# 2. Add a deployment registry
+## 2. Add an image registry.
 
-Before projects can be deployed on Kubernetes, you must specify a Docker push registry. This example uses Docker Hub. 
+Before projects can be deployed on Kubernetes, specify a Docker push registry. This example uses Docker Hub. 
 
-1\. Right-click on your remote connection in the Codewind Explorer view, and select `Manage Image Registries`:
+1\. Right-click your remote connection in the Codewind Explorer view, and select **Manage Image Registries**:
 
 ![Docker Registry](./images/remoteeclipse/connectionSettings.png)
-
 
 2\. Locate and click **Add...** to create a new registry:
 
@@ -60,14 +54,14 @@ Before projects can be deployed on Kubernetes, you must specify a Docker push re
 
 ![New Registry](./images/remoteeclipse/newReg1.png)
 
-1. Add your Docker Hub username.
-2. Add your Docker Hub password.
-3. Click the checkbox to desigate this registry as push registry.
-4. Your Docker Hub namespace (which is usually the same as your user name).
+- Add your Docker Hub username.
+- Add your Docker Hub password.
+- Click the checkbox to desigate this registry as a push registry.
+- Enter your Docker Hub namespace, which is usually the same as your user name.
 
-The connection is tested to validate your credentials, and these are then stored in a Kubernetes secret within the Codewind service.
+The connection is tested to validate your credentials, which are then stored in a Kubernetes secret within the Codewind service.
 
-# 3. Create a new project
+## 3. Create a new project.
 
 1\. In the Codewind Explorer view, right-click your remote connection and select **Create New Project...**:
 
@@ -77,32 +71,84 @@ The connection is tested to validate your credentials, and these are then stored
 
 ![Adding new remote project](./images/remoteeclipse/runningProject.png)
 
-# 4. Copying an existing local project to the cloud
+## 4. Copying an existing local project to the cloud.
 
-The following procedure copies an existing local project `myFirstNodeProject` to the remote Codewind deployment:
+The following procedure copies an existing local project, `myFirstNodeProject` to the remote Codewind deployment:
 
 1\. Right-click your remote connection in the Codewind Explorer view and select **Add Existing Project...**:
 
 ![Add existing project](./images/remoteeclipse/addExistingProject.png)
 
-2\. Navigate to the folder containing your local project files, or choose the previously created `myFirstNodeProject` from the workspace. Click **Next** to proceed:
+2\. Go to the folder that contains your local project files, or choose the previously created `myFirstNodeProject` from the workspace. Click **Next**:
 
 ![Add to Codewind](./images/remoteeclipse/existingProject.png)
 
-3\. Codewind prompts you to confirm the project type identified as `Node.js`:
+3\. Codewind prompts you to confirm the project type identified as **Node.js**:
 
 ![Confirm Project Type](./images/remoteeclipse/confirmProjectType.png)
 
 4\. Click **Finish**.
 
-The project files are copied over to the Codewind server and the new `myFirstNodeProject` appears under your remote connection. Codewind builds your application code and Docker image, and moments later, the project image is uploaded to Docker Hub and used by your cloud deployment to provision a new pod:
+The project files are copied over to the Codewind server, and the new `myFirstNodeProject` appears under your remote connection. Codewind builds your application code and Docker image, and moments later, the project image is uploaded to Docker Hub and used by your cloud deployment to provision a new pod:
 
 ![Build Success](./images/remoteeclipse/buildSuccess.png)
 
-`myFirstNodeProject` on `CloudName1` cluster is now running and ready.
+The `myFirstNodeProject` project on `CloudName1` cluster is now running and ready.
 
-# Next Steps
+# Adding an image registry in remote Codewind
 
-You have now finished configuring Codewind to be used remotely. 
+## Prerequisite: Determining if you need an image registry 
+1\. First, determine if you need to add an image registry. The following scenarios in Codewind require you to specify which image registry is in use:
+- In the following scenario, configure Codewind with an image registry to push the application image to that specific image registry:
+    - Run Codewind on a remote Kubernetes cluster to develop a Codewind style project.
+- In the following scenario, configure Codewind to use the credentials for a specific image registry:
+    - Run Codewind on a remote Kubernetes cluster to develop an Appsody style project.
+    - The image registry for the Appsody stack requires credentials.
+- In the following scenario, from the command line, enter the `docker login` command in the registry before you create the Appsody project:
+    - Run Codewind locally to develop an Appsody style project.
+    - The container registry for the Appsody stack requires credentials. 
+If you do not develop any Codewind style projects, and you use an image registry that does not require credentials, you do not need to specify an image registry.
+2\. If you do need to add an image registry, start and run your IDE.
+
+## Adding an image registry in Codewind
+After your IDE is started and running, add the image registry to be used with Codewind.
+1. From your IDE, open the window for adding your image registry. Right-click a remote connection in the Codewind Explorer view and select **Manage Image Registries**.
+2. Then, follow the prompts and fill out the required information to add your image registry. For recommended values for common registries, see the [examples](#examples).
+  - Registry server name, domain name, or address: `<registry-to-push-or-pull-images-to>`
+  - User name: `<Your user name>`
+  - Password or API key: `<Your password or API key>`
+  - Also enter a namespace if you want to use the registry as the push registry.
+
+## Codewind container registry guidance
+When you run Codewind on Kubernetes for Codewind style projects, Codewind uses [`buildah`](https://github.com/containers/buildah) to build container images from Dockerfiles and to push the images to an image registry that you specify. Use the **Image Registry Manager** in your Codewind IDE to configure the registry to use. 
+
+Use any registry as long as `buildah` and the node that Codewind is running on can resolve the registry hostname. If `buildah` cannot resolve the registry hostname, `buildah` cannot push your projects to the registry, and deployment on Kubernetes is prevented.
+
+## Examples:
+These examples show recommended values for common registries. The following image registries are tested and verified with Codewind:
+- Docker Hub:
+    - Address: `docker.io`
+    - Namespace: `<namespace>`
+    - Credentials: Docker Hub user name and password or access token
+    - **Note:** For Docker Hub, the `Namespace` value is likely to be your user name. 
+- Quay.io:
+    - Address: `https://quay.io`
+    - Namespace: `<namespace>`
+    - Credentials: Quay.io user name and encrypted password
+- Artifactory
+    - Address: `<artifactory-hostname>`
+    - Namespace: `<namespace>`
+    - Credentials: Artifactory user name and access token
+- OpenShift Registry
+    - Address: `docker-registry.default.svc:5000`
+    - Namespace: `<project>`
+    - Credentials: OpenShift user name and access token
+
+## Adding registries to OKD and OpenShift
+To use the OpenShift internal container registry with Codewind, see [Adding the OpenShift internal registry with Codewind](openshiftregistry.html).
+
+## Next Steps
+
+You have configured Codewind to be used remotely. 
 
 In the next topic, you will learn how to [use Codewind remotely to build and run projects in your cloud](./remotedeploy-projects.html).

--- a/docs/_documentations/remotedeploy-vscode.md
+++ b/docs/_documentations/remotedeploy-vscode.md
@@ -12,17 +12,15 @@ order: 2
 
 # Connecting VS Code to remote Codewind
 
-Ensure you have [satisfied all prequisites](./remote-codewind-overview.html). 
+Complete the [prequisites](./remote-codewind-overview.html). 
 
 # Objectives
 
 In this topic you will:
-
 1. Connect Codewind on VS Code to the remote instance of Codewind in the cloud. 
-
 2. Add a deployment registry.
 
-# 1. Connect your IDE's Codewind extension to your remote instance of Codewind
+## 1. Connect your IDE's Codewind extension to your remote instance of Codewind.
 
 1\. Locate the Codewind view in VS Code and click the cloud icon to launch the new connection wizard:
 
@@ -42,9 +40,9 @@ The IDE validates the connection and adds it to the Codewind panel:
 
 The IDE and Codewind are connected.
 
-# 2. Add a deployment registry
+## 2. Add a deployment registry.
 
-Before projects can be deployed on Kubernetes, you need to specify a Docker Registry. Docker Hub is used in this example: 
+Before projects can be deployed on Kubernetes, specify a Docker Registry. Docker Hub is used in this example: 
 
 1\. If it's not already open, go to the connection details page with the link:
 
@@ -62,16 +60,67 @@ Before projects can be deployed on Kubernetes, you need to specify a Docker Regi
 
 ![New Registry](./images/remotevs/newReg1.png)
 
-Enter:
-
-1. Your Docker Hub user name.
-2. Your Docker Hub password.
-3. Your namespace, which is usually the same as your user name.
+Fill in the information:
+- Your Docker Hub user name
+- Your Docker Hub password
+- Your namespace, which is usually the same as your user name
 
 The connection is tested to validate your credentials and stored in a Kubernetes secret within the Codewind service.
 
-# Next Steps
+# Adding an image registry in remote Codewind
 
-You have now finshed configuring Codewind to be used remotely. 
+## Prerequisite: Determining if you need an image registry 
+1\. First, determine if you need to add an image registry. The following scenarios in Codewind require you to specify which image registry is in use:
+- In the following scenario, configure Codewind with an image registry to push the application image to that specific image registry:
+    - Run Codewind on a remote Kubernetes cluster to develop a Codewind style project.
+- In the following scenario, configure Codewind to use the credentials for a specific image registry:
+    - Run Codewind on a remote Kubernetes cluster to develop an Appsody style project.
+    - The image registry for the Appsody stack requires credentials.
+- In the following scenario, from the command line, enter the `docker login` command in the registry before you create the Appsody project:
+    - Run Codewind locally to develop an Appsody style project.
+    - The container registry for the Appsody stack requires credentials. 
+If you do not develop any Codewind style projects, and you use an image registry that does not require credentials, you do not need to specify an image registry.
+2\. If you do need to add an image registry, start and run your IDE.
+
+## Adding an image registry in Codewind
+After your IDE is started and running, add the image registry to be used with Codewind.
+1. From your IDE, open the window for adding your image registry. Right-click a remote connection and select **Image Registry Manager** or use the **Image Registry Manager** command on the command palette.
+2. Then, follow the prompts and fill out the required information to add your image registry. For recommended values for common registries, see the [examples](#examples).
+  - Registry server name, domain name, or address: `<registry-to-push-or-pull-images-to>`
+  - User name: `<Your user name>`
+  - Password or API key: `<Your password or API key>`
+  - Also enter a namespace if you want to use the registry as the push registry.
+
+## Codewind container registry guidance
+When you run Codewind on Kubernetes for Codewind style projects, Codewind uses [`buildah`](https://github.com/containers/buildah) to build container images from Dockerfiles and to push the images to an image registry that you specify. Use the **Image Registry Manager** in your Codewind IDE to configure the registry to use. 
+
+Use any registry as long as `buildah` and the node that Codewind is running on can resolve the registry hostname. If `buildah` cannot resolve the registry hostname, `buildah` cannot push your projects to the registry, and deployment on Kubernetes is prevented.
+
+## Examples:
+These examples show recommended values for common registries. The following image registries are tested and verified with Codewind:
+- Docker Hub:
+    - Address: `docker.io`
+    - Namespace: `<namespace>`
+    - Credentials: Docker Hub user name and password or access token
+    - **Note:** For Docker Hub, the `Namespace` value is likely to be your user name. 
+- Quay.io:
+    - Address: `https://quay.io`
+    - Namespace: `<namespace>`
+    - Credentials: Quay.io user name and encrypted password
+- Artifactory
+    - Address: `<artifactory-hostname>`
+    - Namespace: `<namespace>`
+    - Credentials: Artifactory user name and access token
+- OpenShift Registry
+    - Address: `docker-registry.default.svc:5000`
+    - Namespace: `<project>`
+    - Credentials: OpenShift user name and access token
+
+## Adding registries to OKD and OpenShift
+To use the OpenShift internal container registry with Codewind, see [Adding the OpenShift internal registry with Codewind](openshiftregistry.html).
+
+## Next Steps
+
+You have configured Codewind to be used remotely. 
 
 In the next topic, you will learn how to [use Codewind remotely to create and import projects](./remotedeploy-projects-vscode.html).


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

PR for issue https://github.com/eclipse/codewind/issues/2382.

On March 9th, I met with Mel to discuss https://github.com/eclipse/codewind/issues/2382. Instead of copying section 2 in remotedeploy-eclipse.md/remotedeploy-vscode.md and pasting it into remote-setupregistries.md, I have moved into the contents of remote-setupregistries.md into both  remotedeploy-eclipse.md/remotedeploy-vscode.md.

If we merge this PR, we also need to delete the file remote-setupregistries.md.