### PR TITLE
[WIP]: revisions on private registry draft

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -92,6 +92,8 @@
       url: project-settings.html 
     - title: 'Referencing files external to a project'
       url: referencing-files.html
+    - title: `Developing with packages from private registries and repositories` 
+      url: private-registries.html  
     - title: Using Codewind offline
       url: offline-codewind.html
       

--- a/docs/_documentations/offline-codewind.md
+++ b/docs/_documentations/offline-codewind.md
@@ -10,11 +10,11 @@ type: document
 
 # Using Codewind offline
 When you have limited or no internet access, you can continue to work on projects in Codewind if you meet these conditions:
-- The project was created and was run successfully when you had internet access.
+- The project was created and ran successfully when you had internet access.
 - You make changes to your code without pulling in new dependencies.
 - You do not remove the project container images that Codewind built on your system.
 
-## You can work with these projects offline:
+## You can work with these projects offline
 - Appsody Kitura
 - Appsody LoopBack 4
 - Appsody Python Flask

--- a/docs/_documentations/private-registries.md
+++ b/docs/_documentations/private-registries.md
@@ -1,0 +1,35 @@
+---
+layout: docs
+title: Developing with packages from private registries and repositories 
+description: Developing with packages from private registries and repositories 
+keywords: install, installing, IntelliJ, Eclipse, Codewind, IDE, plugin, plug-in, settings, creating, project, projects, template, code change, edit, edits, application, removing, private, registry, registries, repository, repositories, package, package 
+duration: 5 minutes 
+permalink: private-registries  
+type: document 
+---
+
+# Developing with packages from private registries and repositories 
+
+Packages, reusable pieces of software, help you build and reduce development time. Sometimes, the packages for your application must be installed from an external private registry or one hosted by your organization. Registries help you manage your code and dependencies. Codewind supports two private registry types: NPM registries for Node.js projects and Maven repositories for Java projects. 
+
+## Developing with packages from private NPM registries 
+
+1. Configure your local system to access the private registry. To do this, add the registry configuration and credentials to your profile's `.npmrc` file. For more information, refer to the [NPM documentation](https://docs.npmjs.com/configuring-npm/npmrc.html). 
+    **Note:** you should not put the `.npmrc` file inside your project as it contains sensitive data.
+2. Add a [reference](referencing-files.html) to the `.npmrc` file in your project.
+3. Install packages from the configured registry to your project locally (e.g. `npm install @myorg/mypackage`).Once Codewind builds the Docker image for your applicaiton, it can pull down the packages from the private registry you have configured.
+
+## Developing with packages from private Maven repositories 
+
+1. Configure your local system to access the private repository. To do this, add the repository server credentials to your profile's `settings.xml` file. For more information, refer to the [Maven documentation](https://maven.apache.org/settings.html#Servers). 
+    **Note:** you should not put the `settings.xml` file inside your project as it contains sensitive data.
+2. Add a [reference](referencing-files.html) to the `settings.xml` file in your project.
+3. Modify your `pom.xml` file, then add the appropriate configuratioin to your `<repositories>`/`<pluginRepositories>`, then add your `<dependencies>` element references to the packages your application requires. Once Codewind builds the Docker image for your application, it can pull down the packages from the private repository you have configured.
+
+## Supported project types 
+
+You can apply all the preceding instructions to these project types:
+
+* Lagom Java
+* Node.js Express
+* Open Liberty 

--- a/docs/_documentations/private-registries.md
+++ b/docs/_documentations/private-registries.md
@@ -17,14 +17,14 @@ Packages, reusable pieces of software, help you build and reduce development tim
 1. Configure your local system to access the private registry. To do this, add the registry configuration and credentials to your profile's `.npmrc` file. For more information, refer to the [NPM documentation](https://docs.npmjs.com/configuring-npm/npmrc.html). 
     **Note:** you should not put the `.npmrc` file inside your project as it contains sensitive data.
 2. Add a [reference](referencing-files.html) to the `.npmrc` file in your project.
-3. Install packages from the configured registry to your project locally (e.g. `npm install @myorg/mypackage`).When Codewind builds the Docker image for your application, it pulls down the packages from the private registry you have configured.
+3. Install packages from the configured registry to your project locally (e.g. `npm install @myorg/mypackage`). When Codewind builds the Docker image for your application, it pulls down the packages from the private registry you have configured.
 
 ## Developing with packages from private Maven repositories 
 
 1. Configure your local system to access the private repository. To do this, add the repository server credentials to your profile's `settings.xml` file. For more information, refer to the [Maven documentation](https://maven.apache.org/settings.html#Servers). 
     **Note:** you should not put the `settings.xml` file inside your project as it contains sensitive data.
 2. Add a [reference](referencing-files.html) to the `settings.xml` file in your project.
-3. Modify your `pom.xml` file, add the appropriate configuration to your `<repositories>`/`<pluginRepositories>`, then add the packages your application requires to your `<dependencies>` element references. When Codewind builds the Docker image for your application, it pulls down the packages from the private repository you have configured.
+3. Modify your `pom.xml` file, add the appropriate configuration to your `<repositories>`/`<pluginRepositories>`, then add the packages your application requires to your `<dependencies>` references. When Codewind builds the Docker image for your application, it pulls down the packages from the private repository you have configured.
 
 ## Supported project types 
 

--- a/docs/_documentations/private-registries.md
+++ b/docs/_documentations/private-registries.md
@@ -17,14 +17,14 @@ Packages, reusable pieces of software, help you build and reduce development tim
 1. Configure your local system to access the private registry. To do this, add the registry configuration and credentials to your profile's `.npmrc` file. For more information, refer to the [NPM documentation](https://docs.npmjs.com/configuring-npm/npmrc.html). 
     **Note:** you should not put the `.npmrc` file inside your project as it contains sensitive data.
 2. Add a [reference](referencing-files.html) to the `.npmrc` file in your project.
-3. Install packages from the configured registry to your project locally (e.g. `npm install @myorg/mypackage`).Once Codewind builds the Docker image for your applicaiton, it can pull down the packages from the private registry you have configured.
+3. Install packages from the configured registry to your project locally (e.g. `npm install @myorg/mypackage`).When Codewind builds the Docker image for your application, it pulls down the packages from the private registry you have configured.
 
 ## Developing with packages from private Maven repositories 
 
 1. Configure your local system to access the private repository. To do this, add the repository server credentials to your profile's `settings.xml` file. For more information, refer to the [Maven documentation](https://maven.apache.org/settings.html#Servers). 
     **Note:** you should not put the `settings.xml` file inside your project as it contains sensitive data.
 2. Add a [reference](referencing-files.html) to the `settings.xml` file in your project.
-3. Modify your `pom.xml` file, then add the appropriate configuratioin to your `<repositories>`/`<pluginRepositories>`, then add your `<dependencies>` element references to the packages your application requires. Once Codewind builds the Docker image for your application, it can pull down the packages from the private repository you have configured.
+3. Modify your `pom.xml` file, add the appropriate configuration to your `<repositories>`/`<pluginRepositories>`, then add the packages your application requires to your `<dependencies>` element references. When Codewind builds the Docker image for your application, it pulls down the packages from the private repository you have configured.
 
 ## Supported project types 
 


### PR DESCRIPTION
Signed-off-by: Jacob Berger <jacob.berger@ibm.com>

I made this PR, building off of Andrew's PR #501 for issue [#2469](https://github.com/eclipse/codewind/issues/2469) 

@makandre, I didn't start a review, suggesting my changes, in your PR, because I initially thought we could combine this private registry doc with the doc, ```offline-codewind```. Hence, I made a new doc. Now though, I don't think they should be combined. Leave them as separate for now. 

I wanted to explain during what times users would need to install the packages for their applications from external registries. I wasn't able to figure out a certain situation, but I did give some context as to what packages and registries are. Let me know if you think this is necessary. 

Let me know what you think about these changes (I reworded the titles and commands). If you like them, we can apply them to your doc. I can start a review on your PR if you'd rather see the changes depicted in that way.

Thanks! 