### PR TITLE
Add image border and fix up image caption

### DIFF
--- a/docs/_blog/2019-12-19-sneak-peek-remote-development-with-codewind.md
+++ b/docs/_blog/2019-12-19-sneak-peek-remote-development-with-codewind.md
@@ -30,6 +30,7 @@ Now, why is this so cool?
 
 ![image of the dependency microservice](images/blog/sneakpeakremotedevelopment.jpeg){:width="800px"}
 *You can have all your projects in one editor and still deploy to multiple clouds.*
+{: style="text-align: center;"}
 
 TL;DR:
 - Codewind now supports connecting your local IDE of choice to Codewind installed in a remote cloud.

--- a/docs/css/blog.css
+++ b/docs/css/blog.css
@@ -38,9 +38,11 @@
 }
 
 #post-content img {
-    display: block; 
+    display: block;
     margin-left: auto;
     margin-right: auto;
+    padding-left: 1px;
+    padding-right: 1px;
 }
 
 .author-images-container {

--- a/docs/css/docs.css
+++ b/docs/css/docs.css
@@ -249,8 +249,6 @@ code {
 }
 
 
-
-
 @media only screen and (max-width: 768px) {
 	.cw-docs-spacer {
         height: 0px;
@@ -289,4 +287,8 @@ code {
 
 .highlighter-rouge {
 	color: #123456;
+}
+
+.imageborder {
+    border: 1px solid #000;
 }


### PR DESCRIPTION
For https://github.com/eclipse/codewind/issues/2528

Usage examples:
- When more than one property is set for the image: `![image of the dependency microservice](images/blog/sneakpeakremotedevelopment.jpeg){:width="700px" .imageborder}`
- When only the image border is used: `![](images/runningapp.png){: .imageborder}`

Notes:
- I had to fix a caption issue that I found when testing the css class (it was not centered)
- for post-content img, I had to add a left and right padding, otherwise the border gets cut off on one edge
- the newly added class is ".imgborder" with a 1px black border. When you see the generated HTML, you will see "imgborder", but for Jekyll, you need to prefix it with the "."