### PR TITLE
Fix border bug

### DIFF
--- a/docs/_documentations/vsc-codechange.md
+++ b/docs/_documentations/vsc-codechange.md
@@ -16,27 +16,27 @@ To see this feature in action, make a change to the getting started example.
 
 1\. Edit the `index.html` file:
 
-![](images/vsc-codechange.png){:width="800px"}
+![image of the index.html file as it appears in VS Code](images/vsc-codechange.png){:width="800px"}
 
 2\. In the file, find the `Congratulations!` line.
 
-![](images/vsc-codeline.png)
+![image of the congratulations line in the file](images/vsc-codeline.png)
 
 3\. Change the heading from `Congratulations` to `I did this`:
 
-![](images/vsc-ididthis.png)
+![image of the text change](images/vsc-ididthis.png)
 
 The status of the project changes to **Stopped** while the project is rebuilt and deployed:
  
-![](images/vsc-buildstopped.png)
+![image of the stopped project](images/vsc-buildstopped.png)
 
 After a few moments, the status changes back to **Running**:
 
-![](images/vsc-buildrunning.png)
+![image of the running project](images/vsc-buildrunning.png)
 
 4\. Click the **Open Application** icon to show your code change running:
-![](images/launchicon.png)
+![image of the Open Application icon](images/launchicon.png)
 
-![](images/vsc-screenchanged.png)
+![image of the application as it appears in a web browser](images/vsc-screenchanged.png){: .imageborder}
 
 Next step: [Buiding and deploying in a cloud environment](remote-overview.html)

--- a/docs/_documentations/vsc-firstproject.md
+++ b/docs/_documentations/vsc-firstproject.md
@@ -14,38 +14,38 @@ To create your first project:
 
 1\. Click on the prompt in the **Codewind** window.
 
-![](images/createproject.png)
+![image of VS Code without any local Codewind projects](images/createproject.png)
 
 2\. This prompt displays a list of project types for you to select. 
 
-![](images/listtemplates.png)
+![image of the list of project types](images/listtemplates.png)
 
 3\. Scroll through the list until you see **Node.js Express (Default templates)**.
 
-![](images/nodetemplate.png)
+![image of Node.js Express (Default templates) as it appears in the list of project types](images/nodetemplate.png)
 
 4\. Selecting this template prompts you to enter a name for your project.
 
-![](images/projectname.png)
+![image of the text field where you can enter the name of your project](images/projectname.png)
 
 5\. Enter a name and then choose where to create this on disk. For example, `myFirstNodeProject`.
 
-![](images/projloc.png)
+![image of folder locations where you can store the project](images/projloc.png)
 
-6\. Codewind now starts to build and run your very first project. Once complete,the following screen shows your application is built and running.
+6\. Codewind now starts to build and run your very first project. Once complete, the following screen shows your application is built and running.
 
-![](images/allbuilt.png)
+![image of the screen that shows that the project is built and running](images/allbuilt.png)
 
 7\. To view your running application, click on the project name in the **Codewind** window. 
 
-![](images/launch.png)
+![image of VS Code with a Codewind project named myFirstNodeProject](images/launch.png)
 
 8\. Then click the **Open Application** icon.
-![](images/launchicon.png)
+![image of the Open Application icon](images/launchicon.png)
 
 This icon launches your web browser and displays your application.
 
-![](images/runningapp.png)
+![image of the application as it appears in a web browser](images/runningapp.png){: .imageborder}
 
 Congratulations, you have created your first application on Codewind.
 

--- a/docs/css/blog.css
+++ b/docs/css/blog.css
@@ -41,8 +41,7 @@
     display: block;
     margin-left: auto;
     margin-right: auto;
-    padding-left: 1px;
-    padding-right: 1px;
+    padding: 1px 1px 1px 1px;
 }
 
 .author-images-container {

--- a/docs/css/docs.css
+++ b/docs/css/docs.css
@@ -4,8 +4,10 @@
 }
 
 #content-container img {
-	max-width: 100%;
+    max-width: 100%;
+    padding: 1px 1px 1px 1px;
 }
+
 h1, h2 {
 	padding-bottom: .3em;
     border-bottom: 1px solid #eaecef;


### PR DESCRIPTION
On chrome, the border can get cut off. As a result, I need to add 1px padding for all the images in the docs and blogs to ensure it doesn't get cut off. I don't see this problem on other browsers like firefox or safari. Also, when I'm in inspector mode on chrome, it doesn't get cut off either.

The 1px padding ensures the border will always show.