### PR TITLE
Fix border

### DIFF
--- a/docs/css/blog.css
+++ b/docs/css/blog.css
@@ -41,8 +41,7 @@
     display: block;
     margin-left: auto;
     margin-right: auto;
-    padding-left: 1px;
-    padding-right: 1px;
+    padding: 1px 1px 1px 1px;
 }
 
 .author-images-container {

--- a/docs/css/docs.css
+++ b/docs/css/docs.css
@@ -4,8 +4,10 @@
 }
 
 #content-container img {
-	max-width: 100%;
+    max-width: 100%;
+    padding: 1px 1px 1px 1px;
 }
+
 h1, h2 {
 	padding-bottom: .3em;
     border-bottom: 1px solid #eaecef;


### PR DESCRIPTION
On chrome, the border can get cut off. As a result, I need to add 1px padding for all the images in the docs and blogs to ensure it doesn't get cut off. I don't see this problem on other browsers like firefox or safari. Also, when I'm in inspector mode on chrome, it doesn't get cut off either.

The 1px padding ensures the border will always show.