### PR TITLE
Adding documentation for debugging

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -84,6 +84,8 @@
       url: private-registries.html  
     - title: 'Using Codewind offline'
       url: offline-codewind.html
+    - title: 'Debugging in Codewind'
+      url: debugging.html
       
 - title: 'Performance monitoring'
   children:

--- a/docs/_documentations/checkingstatuses.md
+++ b/docs/_documentations/checkingstatuses.md
@@ -6,8 +6,6 @@ keywords: using, run, monitor, getting started,  builds, changes, status, state,
 duration: 1 minute
 permalink: checkingstatuses
 type: document
-parent: usingcodewind
-order: 7
 ---
 
 # Understanding application and build statuses

--- a/docs/_documentations/debugging.md
+++ b/docs/_documentations/debugging.md
@@ -13,7 +13,7 @@ type: document
 Complete the following steps to enable debugging in Codewind applications:
 
 1. In the Codewind view, right-click a project and select **Restart in Debug Mode** from the menu.
-2. Wait for the project state to switch to **Debugging**. The first time that the project switches to **Debugging**, the debugger is attached.
-3. When in debug mode, you can perform the debugging actions that are included with your IDE.
-4. To switch back to run mode, right-click your project and select **Restart in Run Mode** from the menu.
-5. If you want to return to debug mode after detaching or ending the debug process, right-click your project and select **Attach Debugger** from the menu.
+2. Wait for the project state to switch to **Debugging**. After it switches to Debugging mode, the debugger is attached.
+3. When in Debugging mode and when the debugger is attached, you can debug your application. Perform debug actions that are supported by the IDE that you are using.
+4. While the project is still in Debugging mode, if the debug process is detached, right-click your project and select **Attach Debugger** from the menu. This action reattaches the debugger to the debug process, and you can continue with debugging your application.
+5. To switch back to run mode, right-click your project and select **Restart in Run Mode** from the menu.

--- a/docs/_documentations/debugging.md
+++ b/docs/_documentations/debugging.md
@@ -1,0 +1,19 @@
+---
+layout: docs
+title: Debugging in Codewind
+description: Debugging in Codewind
+keywords: debug, mode, applications, application, project, menu, view, attaching, attach, actions, action, run, restart in debug mode, attach debugger, debug process, debugging process
+duration: 1 minute
+permalink: debugging
+type: document
+---
+
+# Debugging in Codewind
+
+Complete the following steps to enable debugging in Codewind applications:
+
+1. In the Codewind view, right-click a project and select **Restart in Debug Mode** from the menu.
+2. Wait for the project state to switch to **Debugging**. The first time that the project switches to **Debugging**, the debugger is attached.
+3. When in debug mode, you can perform the debugging actions that are included with your IDE.
+4. To switch back to run mode, right-click your project and select **Restart in Run Mode** from the menu.
+5. If you want to return to debug mode after detaching or ending the debug process, right-click your project and select **Attach Debugger** from the menu.


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

PR for issue https://github.com/eclipse/codewind/issues/2581.

- Adding the debugging document.
- Adding the debugging document to the table of contents.
- Remove unnecessary metadata from the `checkingstatuses.md` file.