### PR TITLE
Fixing formatting, corrections to text

### DIFF
--- a/docs/_documentations/workingwithtemplates.md
+++ b/docs/_documentations/workingwithtemplates.md
@@ -10,7 +10,7 @@ type: document
 
 # Working with templates
 
-Codewind gives you the flexibility to code and develop in languages of your choice by using templates. Templates make application development easier by providing a structure and boilerplate code, or framework, to help you start a new project. Templates appear as a new language and project type within the Codewind user interface. 
+Use Codewind to code and develop in languages of your choice by using templates. Templates make application development easier by providing a structure and boilerplate code, or framework, to help you start a new project. Templates appear as a new language and project type within the Codewind user interface. 
 
 When you create a new project, choose from the default set of templates available in Codewind, or choose a template source of your own. Add more development languages and sample projects by adding new templates.
 
@@ -24,21 +24,24 @@ The **Template Source Manager** provides template management in Codewind. To ope
 
 Codewind templates are stored in the [codewind-resources/codewind-templates](https://github.com/codewind-resources/codewind-templates)
 GitHub repository. Three examples are included in Codewind for your reference: 
-* Standard Codewind Templates.
-* Default templates from Kabanero Collections.
-* Appsody Stacks to develop applications with sharable technology stacks. 
+* Standard Codewind templates
+* Default templates from Kabanero Collections
+* Appsody stacks to develop applications with sharable technology stacks
 
 Use the **Template Source Manager** to perform the following actions:
 
 1. To add a new template source to the table, click **Add New**. For more information, see [Adding your template sources to Codewind](#adding-your-template-sources-to-codewind).
-2. **VS Code:** To remove non-default template sources, click the trash icon. 
-   **Eclipse:** To remove non-default template sources, first make sure you are in the **Manage Template Sources** wizard. Select the non-default templates you want to remove. Then click the **Remove** button.
-3. **VS Code:** Toggle the **Enabled** slide to **On** so template source templates appear in the **Create Project** wizard. 
-   **Eclipse:** In the Manage Template Sources wizard, check the check boxes for the template sources you want to enable. Once done, click the OK button. You should see a notification in the bottom right saying **Updating Template Sources: (0%)**. Once that message disappears, it has successfully set your preferred template sources. 
-   * Use template sources to add style projects to Codewind. 
-   * For example, before adding an Appsody project, enable at least one Appsody-style template source. 
-4. **VS Code:** To disable a set of templates so they do not appear in the **Create Project** wizard, toggle the **Enabled** slide to **Off**.
-   **Eclipse:** In the Manage Template Sources, simply uncheck the template sources you want to disable, and then click OK.
+2. Remove non-default template sources.
+   - **VS Code:** Click the trash icon. 
+   - **Eclipse:** First make sure you are in the **Manage Template Sources** wizard. Select the non-default templates you want to remove. Then click **Remove**.
+3. Add templates to the wizard.
+   - **VS Code:** Toggle the **Enabled** slide to **On** so template source templates appear in the **Create Project** wizard.
+   - **Eclipse:** In the **Manage Template Sources** wizard, check the check boxes for the template sources you want to enable. After you're done, click **OK**. A notification appears that says, **Updating Template Sources: (0%)**. The message disappears after the wizard successfully sets your preferred template sources.
+   - Use template sources to add style projects to Codewind. 
+   - For example, before adding an Appsody project, enable at least one Appsody-style template source.
+4. Disable templates to prevent them from appearing in the wizard.
+   - **VS Code:** To disable a set of templates so they do not appear in the **Create Project** wizard, toggle the **Enabled** slide to **Off**.
+   - **Eclipse:** In **Manage Template Sources**, deselect the template sources you want to disable and click **OK**.
 
 ## Creating your own templates
 
@@ -78,7 +81,9 @@ Add your own template sources to use in the **Template Source Manager**.
 
 Add your template sources to Codewind with the **Template Source Manager**.
 
-1. **VS Code:** In the **Template Source Manager**, click **Add New**. 
-   **Eclipse:** Right-click the connection in the Codewind Explorer view and select **Manage Template Sources...**. After the **Manage Template Sources** wizard appears, click **Add...**.
-2. **VS Code:** Enter the URL to your template source `index` file and click **Enter** to confirm.
-   **Eclipse:** Fill in the fields for **URL**, **Name**, and **Description**. Click **OK** when you're done.
+1. Add the template.
+   - **VS Code:** In the **Template Source Manager**, click **Add New**. 
+   - **Eclipse:** Right-click the connection in the Codewind Explorer view and select **Manage Template Sources...**. After the **Manage Template Sources** wizard appears, click **Add...**.
+2. Enter the URL and any other information.
+   - **VS Code:** Enter the URL to your template source `index` file and click **Enter** to confirm.
+   - **Eclipse:** Fill in the fields for **URL**, **Name**, and **Description**. Click **OK** when you're done.


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

The text for separate VS Code and Eclipse instructions should appear on separate lines. However, it wasn't rendering correctly:
<img width="985" alt="IncorrectSpacing" src="https://user-images.githubusercontent.com/21180723/79254609-fd481880-7e52-11ea-8662-2620a8c41e21.png">

This PR fixes the spacing issue. I've also added other small text enhancements.