### PR TITLE
[0.12.0] Adding docs alt text

### DIFF
--- a/docs/_documentations/eclipse-codechange.md
+++ b/docs/_documentations/eclipse-codechange.md
@@ -17,20 +17,20 @@ To see this feature in action, make a change to the getting started example.
 
 1\. Edit the `index.html` file.
 
-![](images/eclipsechangeproject1.png){:width="800px"}
+![image of the index.html file as it appears in Eclipse](images/eclipsechangeproject1.png){:width="800px"}
 
 2\. In the file, find the `Congratulations!` line.
 
-![](images/eclipsechangeproject2.png)
+![image of the congratulations line in the file](images/eclipsechangeproject2.png)
 
 3\. Change the heading from `Congratulations` to `I did this` and save the file.
 
-![](images/eclipsechangeproject3.png)
+![image of the text change](images/eclipsechangeproject3.png)
 
 4\. Click the **Open Application**
-![](images/eclipseopenprojecticon.png)
+![image of the Open Application icon](images/eclipseopenprojecticon.png)
 icon to show your code change running.
 
-![](images/eclipsechangeproject4.png){:width="800px"}
+![image of the application with the code change](images/eclipsechangeproject4.png){:width="800px"}
 
 Next step: [Buiding and deploying in a cloud environment](remote-deploying-codewind.html)

--- a/docs/_documentations/eclipse-firstproject.md
+++ b/docs/_documentations/eclipse-firstproject.md
@@ -14,32 +14,32 @@ To create your first project:
 
 1\. Right-click the **Local [Running]** item and select **Create New Project...**.
 
-![](images/eclipsecreateproject1.png){:width="800px"}
+![image of the menu where you select Create New Project](images/eclipsecreateproject1.png){:width="800px"}
 
 2\. Creating a new project displays the project creation screen.
 
-![](images/eclipsecreateproject2.png){:width="800px"}
+![image of the project creation screen](images/eclipsecreateproject2.png){:width="800px"}
 
 3\. Enter a name for the project and change the location if you want. Scroll through the list of templates until you see **Node.js Express**. For more information about templates, see [Working with templates](workingwithtemplates.html).
 
-![](images/eclipsecreateproject3.png){:width="800px"}
+![image of the list of templates](images/eclipsecreateproject3.png){:width="800px"}
 
 4\. Select this template and click **Finish**. You now see the project overview screen.
 
-![](images/eclipsecreateproject4.png){:width="800px"}
+![image of the project overview screen](images/eclipsecreateproject4.png){:width="800px"}
 
 5\. Codewind now starts to build and run your very first project. This process initially takes several minutes, depending on the speed of your network and the selected project.
 
 Once complete, the following screen shows your application is built and running. 
 
-![](images/eclipsecreateproject5.png){:width="800px"}
+![image of the screen that shows the application is built and running](images/eclipsecreateproject5.png){:width="800px"}
 
 6\. To view your running application, select it in the Codewind Explorer view and click the **Open Application** icon.
-![](images/eclipseopenprojecticon.png)
+![image of the Open Application icon](images/eclipseopenprojecticon.png)
 
 This icon launches your web browser and displays your application.
 
-![](images/eclipsefirstprojectrunning.png){:width="800px"}
+![image of the application in the web browser](images/eclipsefirstprojectrunning.png){:width="800px"}
 
 Congratulations, you have created your first application on Codewind.
 

--- a/docs/_documentations/vsc-firstproject.md
+++ b/docs/_documentations/vsc-firstproject.md
@@ -12,7 +12,7 @@ order: 2
 <br/>
 To create your first project:
 
-1\. Click on the prompt in the **Codewind** window.
+1\. Click the prompt in the **Codewind** window.
 
 ![image of VS Code without any local Codewind projects](images/createproject.png)
 

--- a/docs/_news/news09.md
+++ b/docs/_news/news09.md
@@ -13,7 +13,7 @@ Thursday, 20 February 2020
 #### ✨ New Features and Highlights for 0.9.0 ✨
 Introducing the tech preview of Codewind on the IntelliJ IDE! We want to make our tools available to as many developers as possible in their preferred IDEs. Many people have asked about IntelliJ, as it is a popular option among Java developers, so we are working hard to bring the effortless Codewind experience to IntelliJ. With this tech preview, you can now use Codewind on IntelliJ locally.
 
-![](images/imagesfornews/intelliJ-techpreview.gif){:width="800"}
+![video of new feature, creating a new project with IntelliJ](images/imagesfornews/intelliJ-techpreview.gif){:width="800"}
 
 Try it out [here](intellij-getting-started.html).
 


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

PR for issue: https://github.com/eclipse/codewind/issues/1897

All the images in the "Docs" tab should have text associated with them now.