### PR TITLE
Fix blog links

### DIFF
--- a/docs/_blog/2019-08-21-introduction-to-eclipse-codewind-build-high-quality-cloud-native-applications-faster.md
+++ b/docs/_blog/2019-08-21-introduction-to-eclipse-codewind-build-high-quality-cloud-native-applications-faster.md
@@ -6,7 +6,7 @@ author_picture: images/blog/author_icon_andy_watson.jpeg
 author_url: 
 author: Andy Watson
 blog_description: "Eclipse Codewind is an open source project that makes it easier for developers to create cloud-native applications within their favorite IDE. Codewind initially supports Visual Studio Code, Eclipse..."
-permalink: introduction-to-eclipse-codewind-build-high-quality-cloud-native-applications-faster
+permalink: introduction-to-eclipse-codewind-build-high-quality-cloud-native-applications-faster.html
 duration: 2 minutes
 tags: [Microservices, Containers, Nodejs, Java, Cloud]
 ---

--- a/docs/_blog/2019-10-18-great-conversations-about-the-kabanero-io.md
+++ b/docs/_blog/2019-10-18-great-conversations-about-the-kabanero-io.md
@@ -6,7 +6,7 @@ author_picture: images/blog/author_icon_nik_canvin.jpg
 author_url: https://www.linkedin.com/in/nik-canvin-110326/
 author: Nik Canvin
 blog_description: "Developers and CTOs alike, shared both enthusiasm and validation for the microservice develop-deploy stories in Kabanero.io at IBM’s ThinkLondon summit yesterday..."
-permalink: great-conversations-about-the-kabanero-io
+permalink: great-conversations-about-the-kabanero-io.html
 duration: 2 minutes
 tags: [Microservices, Cloud, Java, Nodejs]
 ---

--- a/docs/_blog/2019-10-18-my-first-cloud-native-node-js-microservice-from-nothing-to-running-immediately.md
+++ b/docs/_blog/2019-10-18-my-first-cloud-native-node-js-microservice-from-nothing-to-running-immediately.md
@@ -6,7 +6,7 @@ author_picture: images/blog/author_icon_nik_canvin.jpg
 author_url: https://www.linkedin.com/in/nik-canvin-110326/
 author: Nik Canvin
 blog_description: "Having read about the virtues of 12-factor Apps, I knew I wanted to develop a new microservice — something that would handle one task really well and be easy to deploy to any cloud, but did not have..."
-permalink: my-first-cloud-native-node-js-microservice-from-nothing-to-running-immediately
+permalink: my-first-cloud-native-node-js-microservice-from-nothing-to-running-immediately.html
 duration: 5 minutes
 tags: [Docker, Nodejs, Containers, Microservices, Development]
 ---

--- a/docs/_blog/2019-10-30-a-new-microservice-to-provide-node-js-sub-dependency-license-insights.md
+++ b/docs/_blog/2019-10-30-a-new-microservice-to-provide-node-js-sub-dependency-license-insights.md
@@ -6,14 +6,14 @@ author_picture: images/blog/author_icon_nik_canvin.jpg
 author_url: https://www.linkedin.com/in/nik-canvin-110326/
 author: Nik Canvin
 blog_description: "An overview and demonstration of a microservice that automates some Node.js sub-dependency management pain-points, developed using Eclipse Codewind. Note: I covered the pain points and manual..."
-permalink: a-new-microservice-to-provide-node-js-sub-dependency-license-insights
+permalink: a-new-microservice-to-provide-node-js-sub-dependency-license-insights.html
 duration: 3 minutes
 tags: [Nodejs, Licensing, Cloud Computing, Development]
 ---
 
 An overview and demonstration of a microservice that automates some Node.js sub-dependency management pain-points, developed using [Eclipse Codewind](http://ibm.biz/eclipse-cw01).
 
-*Note: I covered the pain points and manual remedies associated with Node.js sub-dependency identification and licensing in a [previous blog](/codewind/checking-node-js-sub-dependencies-licenses-for-usage-and-redistribution). You may also be interested in a lower level technical autopsy of this containerized microservice in this [next blog](/codewind/a-technical-autopsy-of-a-containerized-node-js-dependency-insights-microservice-application).*
+*Note: I covered the pain points and manual remedies associated with Node.js sub-dependency identification and licensing in a [previous blog](/codewind/checking-node-js-sub-dependencies-licenses-for-usage-and-redistribution.html). You may also be interested in a lower level technical autopsy of this containerized microservice in this [next blog](/codewind/a-technical-autopsy-of-a-containerized-node-js-dependency-insights-microservice-application.html).*
 
 ### What does the microservice do?
 Once the user has submitted the Node.js package name and version to check, as well as the NPM install type (clean or not), the microservice downloads the entire package dependency tree needed for production use.
@@ -40,7 +40,7 @@ There were many benefits using a microservice to solve this problem, including:
 - Easy to deploy to any Cloud. I used an instance of OpenShift running internally within IBM (so currently only IBM employees can access this microservice).
 
 ### How was the microservice implemented?
-If you’re interested in a lower level technical autopsy of this containerized microservice then my [next blog](/codewind/a-technical-autopsy-of-a-containerized-node-js-dependency-insights-microservice-application) may be for you, but to keep things simple here’s a quick overview.
+If you’re interested in a lower level technical autopsy of this containerized microservice then my [next blog](/codewind/a-technical-autopsy-of-a-containerized-node-js-dependency-insights-microservice-application.html) may be for you, but to keep things simple here’s a quick overview.
 
 Eclipse Codewind was used to instantly create and run an empty Express Node.js containerised microservice in one simple step.
 

--- a/docs/_blog/2019-10-30-a-technical-autopsy-of-a-containerized-node-js-dependency-insights-microservice-application.md
+++ b/docs/_blog/2019-10-30-a-technical-autopsy-of-a-containerized-node-js-dependency-insights-microservice-application.md
@@ -6,14 +6,14 @@ author_picture: images/blog/author_icon_nik_canvin.jpg
 author_url: https://www.linkedin.com/in/nik-canvin-110326/
 author: Nik Canvin
 blog_description: "This blog focuses on the code to implement a cloud-native serverless Node.js microservice developed using Eclispe Codewind."
-permalink: a-technical-autopsy-of-a-containerized-node-js-dependency-insights-microservice-application
+permalink: a-technical-autopsy-of-a-containerized-node-js-dependency-insights-microservice-application.html
 duration: 5 minutes
 tags: [Nodejs, Cloud Computing, Microservices, Software Development, Licensing]
 
 ---
 This blog focuses on the code to implement a cloud-native serverless Node.js microservice developed using Eclispe Codewind.
 
-Note: To see a quick overview and demonstration of the running microservice from an end users point of view, you may like this [previous blog](/codewind/a-new-microservice-to-provide-node-js-sub-dependency-license-insights).
+Note: To see a quick overview and demonstration of the running microservice from an end users point of view, you may like this [previous blog](/codewind/a-new-microservice-to-provide-node-js-sub-dependency-license-insights.html).
 
 An overview of flow and microservice files:
 
@@ -60,7 +60,7 @@ A more in-depth look at the key files in the microservice:
 14. Else a ‘green’ bill of health informs the user that they may use their package without further action.
 15. Then in a collapsable format, first all the ‘red’ packages are displayed (with a drill to salient comments), then the ‘amber’ ones and finally the ‘green’ ones at the bottom.
 
-To get a new containerized microservice up and running immediately without any Kubernetes or Docker skills at all, I used Eclispe Codewind. See this [introduction](/codewind/introduction-to-eclipse-codewind-build-high-quality-cloud-native-applications-faster) to follow in my footsteps.
+To get a new containerized microservice up and running immediately without any Kubernetes or Docker skills at all, I used Eclispe Codewind. See this [introduction](/codewind/introduction-to-eclipse-codewind-build-high-quality-cloud-native-applications-faster.html) to follow in my footsteps.
 
 **All projects created using the Eclipse Codewind Express Node.js project template that I used, contain the following key files:**
 
@@ -98,4 +98,4 @@ Using the Eclipse Codewind develop tools instantly created a fully formed and st
 {: style="text-align: center;"}
 
 The application was completed by adding the code in files described above.
-To see the final microservice in action, you may like to visit this previous blog: [“A new microservice to provide ‘Node.js sub-dependency license insights’”](/codewind/a-new-microservice-to-provide-node-js-sub-dependency-license-insights)
+To see the final microservice in action, you may like to visit this previous blog: [“A new microservice to provide ‘Node.js sub-dependency license insights’”](/codewind/a-new-microservice-to-provide-node-js-sub-dependency-license-insights.html)

--- a/docs/_blog/2019-10-30-checking-node-js-sub-dependencies-licenses-for-usage-and-redistribution.md
+++ b/docs/_blog/2019-10-30-checking-node-js-sub-dependencies-licenses-for-usage-and-redistribution.md
@@ -6,7 +6,7 @@ author_picture: images/blog/author_icon_nik_canvin.jpg
 author_url: https://www.linkedin.com/in/nik-canvin-110326/
 author: Nik Canvin
 blog_description: "Reusing Node.js modules from NPM is technically easy, but understanding the commercial legal usage and redistribution implications can be a ‘black art’."
-permalink: checking-node-js-sub-dependencies-licenses-for-usage-and-redistribution
+permalink: checking-node-js-sub-dependencies-licenses-for-usage-and-redistribution.html
 duration: 5 minutes
 tags: [JavaScript, Nodejs, Licensing, Project Management, Software Development]
 ---
@@ -19,7 +19,7 @@ Reusing Node.js modules from NPM is technically easy, but understanding the comm
 
 Working as a software project manager for the last 2 years on an offering which uses 1000s of open source packages and releases every four weeks, I’ve spent considerable time discovering, understanding and manually working through several pain points regarding open source (OS) sub-dependency identification and licensing challenges.
 
-*Note: In my case I needed automation to keep up with both my project’s consumption of new OS packages, as well as the OS community’s appetite to continuously update their packages. A new microservice was developed for use by my team, which I’ve shared in a separate blog here: “[A new microservice to provide Node.js sub-dependency license insights](/codewind/a-new-microservice-to-provide-node-js-sub-dependency-license-insights).”*
+*Note: In my case I needed automation to keep up with both my project’s consumption of new OS packages, as well as the OS community’s appetite to continuously update their packages. A new microservice was developed for use by my team, which I’ve shared in a separate blog here: “[A new microservice to provide Node.js sub-dependency license insights](/codewind/a-new-microservice-to-provide-node-js-sub-dependency-license-insights.html).”*
 
 ![image of license chcker](images/blog/npmdependencies_2.png){:width="800px"}
 *Enter a package name and version to check (left window) and license results (right window)*
@@ -63,7 +63,7 @@ As the use of open source continues to balloon with the exponential growth of su
 
 ![image of Codewind](images/blog/npmdependencies_3.png){:width="800px"}
 
-Using the Eclipse Codewind developer tools, the automation in this case was implemented as a microservice to enable the widest possible reuse within my company, either as-is or as part of other parties’ automation workflows. Find out more in this related blog: “[A new microservice to provide Node.js sub-dependency license insights.](/codewind/a-new-microservice-to-provide-node-js-sub-dependency-license-insights)”
+Using the Eclipse Codewind developer tools, the automation in this case was implemented as a microservice to enable the widest possible reuse within my company, either as-is or as part of other parties’ automation workflows. Find out more in this related blog: “[A new microservice to provide Node.js sub-dependency license insights.](/codewind/a-new-microservice-to-provide-node-js-sub-dependency-license-insights.html)”
 
 Node.js is not the only language with challenging sub-dependency package identification and licensing risks, so similar work drilling into other languages is in progress.
 

--- a/docs/_blog/2019-12-09-enabling-https-in-your-codewind-application.md
+++ b/docs/_blog/2019-12-09-enabling-https-in-your-codewind-application.md
@@ -6,7 +6,7 @@ author_picture: images/blog/author_icon_becca_bau.jpeg
 author_url: 
 author: Becca Bau
 blog_description: "HTTPS is becoming increasingly common as the internet shifts to an HTTPS-only environment. In an unencrypted HTTP session, data is transferred in clear text, meaning anyone can eavesdrop on your..."
-permalink: enabling-https-in-your-codewind-application
+permalink: enabling-https-in-your-codewind-application.html
 duration: 2 minutes
 tags: [Https, Python, Microprofile]
 ---

--- a/docs/_blog/2019-12-10-want-to-get-a-microservice-up-and-running-super-quickly-try-codewind.md
+++ b/docs/_blog/2019-12-10-want-to-get-a-microservice-up-and-running-super-quickly-try-codewind.md
@@ -6,7 +6,7 @@ author_picture: images/blog/author_icon_melanie_hopper.jpeg
 author_url: 
 author: Dr Melanie Hopper
 blog_description: "With Codewind, not only will you be able to choose your microservice from a list of templates, you’ll have a fully integrated container development environment for a smooth inner loop experience."
-permalink: want-to-get-a-microservice-up-and-running-super-quickly-try-codewind
+permalink: want-to-get-a-microservice-up-and-running-super-quickly-try-codewind.html
 duration: 4 minutes
 tags: [Docker, Microservices, Containers, Development, VS Code]
 ---

--- a/docs/_blog/2019-12-19-sneak-peek-remote-development-with-codewind.md
+++ b/docs/_blog/2019-12-19-sneak-peek-remote-development-with-codewind.md
@@ -6,7 +6,7 @@ author_picture: images/blog/author_icon_becca_bau.jpeg
 author_url: 
 author: Becca Bau
 blog_description: "In our Codewind 0.7.0 release, we’re very excited to share with you a preview of our latest feature: a remote development scenario with Codewind! We can hear you asking, “Why should I even care?”..."
-permalink: sneak-peek-remote-development-with-codewind
+permalink: sneak-peek-remote-development-with-codewind.html
 duration: 2 minutes
 tags: [Docker, Kubernetes, Eclipse, Codewind, Remote Development]
 ---

--- a/docs/_blog/2020-03-05-introducting-intellij.md
+++ b/docs/_blog/2020-03-05-introducting-intellij.md
@@ -6,7 +6,7 @@ author_picture: images/blog/author_icon_becca_bau.jpeg
 author_url: 
 author: Becca Bau
 blog_description: "We recently announced the tech preview of Eclipse Codewind on the IntelliJ IDE. Many people have asked about IntelliJ, as it is a popular..."
-permalink: introducing-eclipse-codewind-on-intellij
+permalink: introducing-eclipse-codewind-on-intellij.html
 duration: 3 minutes
 tags: [Microservices, IDE, Intellij, Open Source]
 ---

--- a/docs/_blog/2020-03-18-jdk-14-is-coming-but-will-my-java-application-run-on-it.md
+++ b/docs/_blog/2020-03-18-jdk-14-is-coming-but-will-my-java-application-run-on-it.md
@@ -6,7 +6,7 @@ author_picture: images/blog/author_icon_nik_canvin.jpg
 author_url: https://www.linkedin.com/in/nik-canvin-110326/
 author: Nik Canvin
 blog_description: "Well, ... NO... as it turns out... for my specific application at least, here’s how I tested against JDK14, then found, debugged and fixed an issue in minutes! New versions of the layers in your..."
-permalink: jdk-14-is-coming-but-will-my-java-application-run-on-it
+permalink: jdk-14-is-coming-but-will-my-java-application-run-on-it.html
 duration: 4 minutes
 tags: [JDK, Java, Containers, Cloud Computing, Microservices]
 ---


### PR DESCRIPTION
For fixing https://github.com/eclipse/codewind/issues/2688

The jekyll container must do some automatic redirection. For example, if the url /codewind/happy goes redirects to /codewind/happy.html (but still shows as /codewind/happy in the URL bar). They are likely doing some sort of .htaccess redirect.

The fix is to add the `.html` to the URL of each blog. We don't do this in our regular codewind docs, but that is because we have code that hijacks the URL and appends a .html to it. I think that could be a bit confusing and I prefer that the URL has the .html in it, so it better matches what the output is on eclipse.org. 

For the blog fix, this is a super low risk fix. In the blog posts that reference other blog posts, I added the .html to the URL, which matches what we do in the regular docs too.

Lastly, this fixes the linkchecker and build.sh issues we were seeing before.