### PR TITLE
Adding guides folder

### DIFF
--- a/docs/_guides/sampleguide.md
+++ b/docs/_guides/sampleguide.md
@@ -1,0 +1,12 @@
+---
+:layout: doc
+:title: Sample guide
+:description: Sample guide
+:keywords: Sample guide
+:duration: 5 minutes 
+:permalink: sampleguide
+:type: guide
+---
+
+# Sample guide
+This file is a placeholder until the team merges guides into the `_guides` folder.


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

PR for issue https://github.com/eclipse/codewind/issues/2725.

This is a folder where the guides will be stored. I cannot create an empty folder, so I have included a sample guide file within. After Jake adds real guides to this folder, we can delete the sample guide file.