### PR TITLE
Renaming "'Creating your first [IDE] Codewind project" files + TOC titles

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -12,7 +12,7 @@
       children:
       - title: 'Installing Codewind for VS Code'
         url: vsc-getting-started.html
-      - title: 'Creating your first VS Code Codewind project'
+      - title: 'Creating your first Codewind project with Codewind for VS Code'
         url: vsc-firstproject.html
       - title: 'Making a code change with VS Code'
         url: vsc-codechange.html
@@ -20,7 +20,7 @@
       children:
       - title: 'Installing Codewind for Eclipse'
         url: eclipse-getting-started.html
-      - title: 'Creating your first Eclipse Codewind project'
+      - title: 'Creating your first Codewind project with Codewind for Eclipse'
         url: eclipse-firstproject.html
       - title: 'Making a code change with Eclipse'
         url: eclipse-codechange.html
@@ -28,7 +28,7 @@
       children:
       - title: 'Installing Codewind for IntelliJ'
         url: intellij-getting-started.html
-      - title: 'Creating your first IntelliJ Codewind project'
+      - title: 'Creating your first Codewind project with Codewind for IntelliJ'
         url: intellij-firstproject.html
       - title: 'Making a code change with IntelliJ'
         url: intellij-codechange.html
@@ -45,7 +45,7 @@
         url: che-setupregistries.html
       - title: 'Creating a Codewind workspace in Che'
         url: che-createcodewindworkspace.html
-      - title: 'Creating your first project with Codewind for Eclipse Che'
+      - title: 'Creating your first Codewind project with Codewind for Eclipse Che'
         url: che-createfirstproject.html
       - title: 'Configuring Codewind for Tekton pipelines'
         url: che-tektonpipelines.html

--- a/docs/_documentations/che-createfirstproject.md
+++ b/docs/_documentations/che-createfirstproject.md
@@ -1,14 +1,14 @@
 ---
 layout: docs
-title: Creating your first project with Codewind for Eclipse Che
-description: Creating your first project with Codewind for Eclipse Che
+title: Creating your first Codewind project with Codewind for Eclipse Che
+description: Creating your first Codewind project with Codewind for Eclipse Che
 keywords: build, deploy, install, installing, installation, chart, develop, cloud, public cloud, services, command line, cli, command, start, stop, update, open, delete, options, operation, devops
 duration: 1 minute
 permalink: che-createfirstproject
 type: document
 ---
 
-# Creating your first project with Codewind for Eclipse Che
+# Creating your first Codewind project with Codewind for Eclipse Che
 
 **Note:** If you already have projects in your Che workspace, such as from your devfile, add them to Codewind with the **Add Existing Project** command instead of the **Create New Project** command.
 

--- a/docs/_documentations/eclipse-firstproject.md
+++ b/docs/_documentations/eclipse-firstproject.md
@@ -1,14 +1,14 @@
 ---
 layout: docs
-title: "Creating your first Eclipse Codewind project"
-description: "Creating your first Eclipse Codewind project"
+title: "Creating your first Codewind project with Codewind for Eclipse"
+description: "Creating your first Codewind project with Codewind for Eclipse"
 keywords: introducing, introduction, overview, what is, tools, vscode, visual, studio, code, java, microprofile, spring, node, nodejs, node.js, javascript, Codewind for VS Code, tools, view, debug, integrate, open a shell session, toggle auto build, manually build, scope VS Code workspace, disable, enable, delete
 duration: 1 minute
 permalink: eclipse-firstproject
 type: document
 order: 2
 ---
-# Creating your first Eclipse Codewind project
+# Creating your first Codewind project with Codewind for Eclipse
 <br/>
 To create your first project:
 

--- a/docs/_documentations/intellij-firstproject.md
+++ b/docs/_documentations/intellij-firstproject.md
@@ -1,14 +1,14 @@
 ---
 layout: docs
-title: Creating your first IntelliJ Codewind project
-description: Creating your first IntelliJ Codewind project
+title: Creating your first Codewind project with Codewind for IntelliJ
+description: Creating your first Codewind project with Codewind for IntelliJ
 keywords: start, starting, template, templates, install, installed, Java, location, locations, field, name, file, files, notification, notifications, pom.xml, structure, Maven, view, views, application, open, build, local, remove, removing, delete, deleting, system, change, changes, changing
 duration: 1 minute
 permalink: intellij-firstproject
 type: document
 ---
 
-# Creating your first IntelliJ Codewind project
+# Creating your first Codewind project with Codewind for IntelliJ
 
 ## Creating your first project from a template
 1. Start IntelliJ. From the welcome page, click **Create New Project**. The **New Project** window opens.

--- a/docs/_documentations/vsc-firstproject.md
+++ b/docs/_documentations/vsc-firstproject.md
@@ -1,14 +1,14 @@
 ---
 layout: docs
-title: "Creating your first VS Code Codewind project"
-description: "Creating your first VS Code Codewind project"
+title: "Creating your first Codewind project with Codewind for VS Code"
+description: "Creating your first Codewind project with Codewind for VS Code"
 keywords: introducing, introduction, overview, what is, tools, vscode, visual, studio, code, java, microprofile, spring, node, nodejs, node.js, javascript, Codewind for VS Code, tools, view, debug, integrate, open a shell session, toggle auto build, manually build, scope VS Code workspace, disable, enable, delete
 duration: 1 minute
 permalink: vsc-firstproject
 type: document
 order: 2
 ---
-# Creating your first VS Code Codewind project
+# Creating your first Codewind project with Codewind for VS Code
 <br/>
 To create your first project:
 


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

PR for issue https://github.com/eclipse/codewind/issues/2736.

I have renamed the "'Creating your first [IDE] Codewind project" file titles and the corresponding TOC titles.

Please note that the file titles now take 2 lines on the TOC:
<img width="343" alt="Screen Shot 2020-04-22 at 10 22 41 AM" src="https://user-images.githubusercontent.com/21180723/79994408-eec9b480-8483-11ea-86a0-670077da26a0.png">

I'm OK with this, but tagging @MelHopper and @micgibso for awareness.