### PR TITLE
Adding che-codechange file to TOC

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -45,6 +45,8 @@
         url: che-setupregistries.html
       - title: 'Creating a Codewind workspace in Che'
         url: che-createcodewindworkspace.html
+      - title: Making a code change with Codewind for Eclipse Che
+        url: che-codechange.html
       - title: 'Creating your first Codewind project with Codewind for Eclipse Che'
         url: che-createfirstproject.html
       - title: 'Configuring Codewind for Tekton pipelines'

--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -45,7 +45,7 @@
         url: che-setupregistries.html
       - title: 'Creating a Codewind workspace in Che'
         url: che-createcodewindworkspace.html
-      - title: Making a code change with Codewind for Eclipse Che
+      - title: 'Making a code change with Codewind for Eclipse Che'
         url: che-codechange.html
       - title: 'Creating your first Codewind project with Codewind for Eclipse Che'
         url: che-createfirstproject.html

--- a/docs/_documentations/che-codechange.md
+++ b/docs/_documentations/che-codechange.md
@@ -8,7 +8,7 @@ permalink: che-codechange
 type: document
 ---
 
-# Making a code change
+# Making a code change with Codewind for Eclipse Che
 1. From the Explorer Projects view, find the project you want to edit and open the file you want to change.
 2. Edit the file.
 3. Save your changes. Codewind detects the change and rebuilds the project. The project application status and build status are updated in the Codewind Project Explorer view.


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

PR for issue https://github.com/eclipse/codewind/issues/2735.

Adding the file `che-codechange` to the table of contents.