### PR TITLE
Add Intellij logs directory

### DIFF
--- a/docs/_documentations/troubleshooting.md
+++ b/docs/_documentations/troubleshooting.md
@@ -842,6 +842,7 @@ The format of the command is:
 Command options are:
 * `--conid remote` - Triggers diagnostics collection for the remote codewind instance (_must_ have currently configured Kubectl connection, default:"local")
 * `--eclipseWorkspaceDir/-e <value>` - The location of your Eclipse workspace directory if using the Eclipse IDE, default:"")
+* `--intellijLogsDir/-i <value>` - The location of your IntelliJ logs directory if using the IntelliJ IDE (default: "")
 * `--quiet/-q` - Turn off console messages
 * `--projects/-p` - Collect project containers information
 * `--nozip/-n` - Does not create collection zip and leaves individual collected files in place


### PR DESCRIPTION
Signed-off-by: micgibso <MICGIBSO@uk.ibm.com>

Add Intellij logs directory to diagnostics. Further PR for https://github.com/eclipse/codewind/issues/2766

@mattcolgate Please review, thx. 