### PR TITLE
Fix false positive for vscode

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ docker run --rm -it \
 docker run -dit --name my-apache-app -p 8765:80 -v "$PWD/docs/_site":/usr/local/apache2/htdocs/codewind/ httpd:2.4
 
 # Check link 
-docker run --network="host" --rm -it -u $(id -u):$(id -g) linkchecker/linkchecker http://localhost:8765/codewind/
+docker run --network="host" --rm -it -u $(id -u):$(id -g) codewinddocs/linkchecker:1.0 http://localhost:8765/codewind/
 rc=$?
 
 # Shut down apache

--- a/linkchecker.bat
+++ b/linkchecker.bat
@@ -1,3 +1,3 @@
 @echo off 
 echo Ensure Codewind docs is running on port 4321
-docker run --network="host" --rm -it linkchecker/linkchecker http://localhost:4321/codewind/
+docker run --network="host" --rm -it codewinddocs/linkchecker:1.0 http://localhost:4321/codewind/

--- a/linkchecker.sh
+++ b/linkchecker.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 echo "Ensure Codewind docs is running on port 4321"
 
-docker run --network="host" --rm -it linkchecker/linkchecker http://0.0.0.0:4321/codewind/
+docker run --network="host" --rm -it codewinddocs/linkchecker:1.0 http://0.0.0.0:4321/codewind/


### PR DESCRIPTION
For issue : https://github.com/eclipse/codewind/issues/1261

I had to add the `vscode` whitelist into a linkchecker docker image and build our own. Now `vscode:extension` will not show up as an invalid link.