### PR TITLE
2915 - Align guides boxes

### DIFF
--- a/docs/_layouts/guides.html
+++ b/docs/_layouts/guides.html
@@ -4,41 +4,42 @@
 <!-- GUIDES -->
 <div id="background-container">
     <div id="guides-container" class="container-fluid">
-        
+
         <div class="row">
-            
+
             <div class="col-lg-12">
                 {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
                 {% assign count = 1 %}
                 {% for post in site.guides reversed %}
 
-                    <div class="row guides-post-row">
-                        <div class="guides-post-column col">
-                            
-                                <div class="guides-post-content guides-content">
-                                    <h2 class="guides-post-title"><a href="{{ post.url | relative_url }}" class="guides-post-title-link">{{ post.title | escape }}</a></h2>
-                                    <p class="guides-post-date-mobile d-sm-block d-md-none">{{ post.date | date: date_format }}</p>
-                                    <p class="guides-post-paragraph">
-                                        {% if post.guide_description %}
-                                            {{ post.guide_description }}
-                                        {% else %}
-                                            {{ post.content | strip_html | truncatewords: 60 }}
-                                        {% endif %}
-                                    </p>
-   
-                                    <div class="read-more-link-container ">
-                                        <a href="{{ post.url | relative_url }}" class="read-more-link">Read more</a>
-                                        </div>
-                                    </div>
-                                </div>
+                <div class="row guides-post-row">
+                    <div class="guides-post-column col">
+
+                        <div class="guides-post-content guides-content">
+                            <h2 class="guides-post-title"><a href="{{ post.url | relative_url }}"
+                                    class="guides-post-title-link">{{ post.title | escape }}</a></h2>
+                            <p class="guides-post-date-mobile d-sm-block d-md-none">{{ post.date | date: date_format }}
+                            </p>
+                            <p class="guides-post-paragraph">
+                                {% if post.guide_description %}
+                                {{ post.guide_description }}
+                                {% else %}
+                                {{ post.content | strip_html | truncatewords: 60 }}
+                                {% endif %}
+                            </p>
+
+                            <div class="read-more-link-container ">
+                                <a href="{{ post.url | relative_url }}" class="read-more-link">Read more</a>
+                            </div>
                         </div>
                     </div>
-                    {% assign count = count | plus: 1 %}
+                </div>
+                {% assign count = count | plus: 1 %}
                 {% endfor %}
-                
+
             </div>
-            
         </div>
+
     </div>
 </div>
 

--- a/docs/css/guides.css
+++ b/docs/css/guides.css
@@ -30,6 +30,10 @@
     color: #292828;
 }
 
+.guides-post-row {
+    width: 100%;
+}
+
 .guides-post-content {
     width: 100%;
     padding-top: 5px;

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -4,4 +4,4 @@ title: Quick guides for Codewind
 description: Quick guides for Codewind
 keywords: guides
 permalink: guides
---- 
+---


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Fixes two bugs in the layout of the guides page. 

- The second box being narrower than the first, for page widths beyond the natural width of the second box. This is resolved by adding `{ width: 100% }` to the row styles. 

- The first box being slightly offset from the second, this was because the             `<div class="col-lg-12">` div was being closed too early. This meant it was only surrounding the first box and therefore that box had double the padding of the second. 

Also formats the `guides.html` file. 

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2915
