### PR TITLE
Use code blocks in guides and docs

### DIFF
--- a/docs/_documentations/referencing-files.md
+++ b/docs/_documentations/referencing-files.md
@@ -14,11 +14,11 @@ order: 0
 
 You can define references to files that reside outside of a project.
 
-To do this: 
+To do this:
 1. Create a file called `.cw-refpaths.json` in your project
 2. Define the references as follows:
 
-```
+```json
 {
     "refPaths": [
         {
@@ -30,7 +30,7 @@ To do this:
 ```
 
 Where:
-- `refPaths` is an array of references. A reference's `from` property is an absolute or relative path to the file you are referencing. Note that you cannot reference directories. 
+- `refPaths` is an array of references. A reference's `from` property is an absolute or relative path to the file you are referencing. Note that you cannot reference directories.
 - The reference's `to` property is a path relative to the root of the project.
 
 Codewind copies the contents of the file that is being referenced, and places it in the file specified by the `to` path when building and running the project.

--- a/docs/_documentations/workingwithtemplates.md
+++ b/docs/_documentations/workingwithtemplates.md
@@ -10,7 +10,7 @@ type: document
 
 # Working with templates
 
-Use Codewind to code and develop in languages of your choice by using templates. Templates make application development easier by providing a structure and boilerplate code, or framework, to help you start a new project. Templates appear as a new language and project type within the Codewind user interface. 
+Use Codewind to code and develop in languages of your choice by using templates. Templates make application development easier by providing a structure and boilerplate code, or framework, to help you start a new project. Templates appear as a new language and project type within the Codewind user interface.
 
 When you create a new project, choose from the default set of templates available in Codewind, or choose a template source of your own. Add more development languages and sample projects by adding new templates.
 
@@ -18,12 +18,12 @@ Codewind provides preconfigured, containerized project templates covering severa
 
 ## Managing templates
 
-The **Template Source Manager** provides template management in Codewind. To open the **Template Source Manager**, right-click a Codewind connection, then **Manage Template Sources**. The **Template Source Manager** appears. 
+The **Template Source Manager** provides template management in Codewind. To open the **Template Source Manager**, right-click a Codewind connection, then **Manage Template Sources**. The **Template Source Manager** appears.
 
 - **Note:** **Template Source Manager** is the name used in VS Code. Eclipse uses the name **Manage Template Sources**.
 
 Codewind templates are stored in the [codewind-resources/codewind-templates](https://github.com/codewind-resources/codewind-templates)
-GitHub repository. Three examples are included in Codewind for your reference: 
+GitHub repository. Three examples are included in Codewind for your reference:
 * Standard Codewind templates
 * Default templates from Kabanero Collections
 * Appsody stacks to develop applications with sharable technology stacks
@@ -32,12 +32,12 @@ Use the **Template Source Manager** to perform the following actions:
 
 1. To add a new template source to the table, click **Add New**. For more information, see [Adding your template sources to Codewind](#adding-your-template-sources-to-codewind).
 2. Remove non-default template sources.
-   - **VS Code:** Click the trash icon. 
+   - **VS Code:** Click the trash icon.
    - **Eclipse:** First make sure you are in the **Manage Template Sources** wizard. Select the non-default templates you want to remove. Then click **Remove**.
 3. Add templates to the wizard.
    - **VS Code:** Toggle the **Enabled** slide to **On** so template source templates appear in the **Create Project** wizard.
    - **Eclipse:** In the **Manage Template Sources** wizard, check the check boxes for the template sources you want to enable. After you're done, click **OK**. A notification appears that says, **Updating Template Sources: (0%)**. The message disappears after the wizard successfully sets your preferred template sources.
-   - Use template sources to add style projects to Codewind. 
+   - Use template sources to add style projects to Codewind.
    - For example, before adding an Appsody project, enable at least one Appsody-style template source.
 4. Disable templates to prevent them from appearing in the wizard.
    - **VS Code:** To disable a set of templates so they do not appear in the **Create Project** wizard, toggle the **Enabled** slide to **Off**.
@@ -53,28 +53,33 @@ Add your own template sources to use in the **Template Source Manager**.
    - Codewind uses [`codewind-templates/devfiles`](https://github.com/codewind-resources/codewind-templates/tree/master/devfiles).
 2. Within this repository, create a folder for each template source.
    - For example, within the `devfiles` folder, Codewind has subfolders for template sources that include Go, MicroProfile, Lagom Java, and more.
-3. Each template source folder needs a `devfile.yaml` file with the following information:<br />
-  `apiVersion: <The version of the API that you use>`<br />
-  `metadata:`<br />
-  `name: <The name of your template>`<br />
-  `projects:`<br />
-    `- name: <The name of your project>`<br />
-      `source:`<br />
-        `type: git`<br />
-        `location: "<The GitHub URL of the template location>"`<br />
+3. Each template source folder needs a `devfile.yaml` file with the following information:
+
+```yaml
+apiVersion: <The version of the API that you use>
+metadata:
+  - name: <The name of your template>
+projects:
+  - name: <The name of your project>
+    source:
+      type: git
+      location: <The GitHub URL of the template location>
+```
 
 4. In the same GitHub repository where you saved the template source folders, create an `index.json` file. In this file, add the following values for each of the templates that you want to work with in Codewind:
-  ```
-  {
-    "displayName":"<The name of your template>",
-    "description":"<The description of your template>",
-    "icon":"<The SVG graphic to be associated with your template>",
-    "language":"<The programming language that your template is written in>",
-    "projectType":"<The project type of your template>",
-    "location":"<The Git repository where the template itself is located>",
-    "links": {"self":"<The template devfile.yaml>" }
-   }
-  ```
+
+```json
+{
+  "displayName":"<The name of your template>",
+  "description":"<The description of your template>",
+  "icon":"<The SVG graphic to be associated with your template>",
+  "language":"<The programming language that your template is written in>",
+  "projectType":"<The project type of your template>",
+  "location":"<The Git repository where the template itself is located>",
+  "links": {"self":"<The template devfile.yaml>" }
+}
+```
+
 - For an example `index.json` file, see the [`index-json` file](https://github.com/codewind-resources/codewind-templates/blob/master/devfiles/index.json) in the `codewind-templates` repository.
 5. To add the templates to Codewind, open your IDE and access the **Template Source Manager**.
 
@@ -83,7 +88,7 @@ Add your own template sources to use in the **Template Source Manager**.
 Add your template sources to Codewind with the **Template Source Manager**.
 
 1. Add the template.
-   - **VS Code:** In the **Template Source Manager**, click **Add New**. 
+   - **VS Code:** In the **Template Source Manager**, click **Add New**.
    - **Eclipse:** Right-click the connection in the Codewind Explorer view and select **Manage Template Sources...**. After the **Manage Template Sources** wizard appears, click **Add...**.
 2. Enter the URL and any other information.
    - **VS Code:** Enter the URL to your template source `index` file and click **Enter** to confirm.

--- a/docs/_guides/codewind-eclipse-quick-guide.md
+++ b/docs/_guides/codewind-eclipse-quick-guide.md
@@ -9,26 +9,28 @@ duration: 5 minutes
 tags: Codewind, Eclipse, microservice
 ---
 
+# Getting Started with Codewind in Eclipse
+
 ## Objectives
-* Install Eclipse and Codewind 
+* Install Eclipse and Codewind
 * Develop a simple microservice, using Eclipse Codewind in Eclipse
 
 
-## Overview 
-Eclipse Codewind provides the ability to create application projects from `Application Stacks` that your company has built, enabling developers to focus on their code and not infrastructure and Kubernetes.  Application deployments to Kubernetes occur via pipelines when developers commit their local code to the correct Git repos Kabanero is managing via webhooks.    
+## Overview
+Eclipse Codewind provides the ability to create application projects from `Application Stacks` that your company has built, enabling developers to focus on their code and not infrastructure and Kubernetes.  Application deployments to Kubernetes occur via pipelines when developers commit their local code to the correct Git repos Kabanero is managing via webhooks.
 
 Eclipse Codewind provides the ability to create projects based on a variety of different template types.  These include IBM Cloud starters, OpenShift Do (odo), and Appsody templates. Today, there are templates for: IBM Cloud Starters, odo, Eclipse MicroProfile/Java EE, Springboot, Node.js, Node.js with Express, and Node.js with Loopback.
 
-## Developing with Eclipse 
+## Developing with Eclipse
 You can use Codewind for Eclipse to develop and debug your containerized projects from within a local Eclipse IDE.
 
 ### Prerequisite
 Before you can develop a microservice with Eclipse, you need to:
 
-* [Install Docker](https://docs.docker.com/install/) 
-    * **Note:** Make sure to install or upgrade to minimum Docker version 19.03. 
+* [Install Docker](https://docs.docker.com/install/)
+    * **Note:** Make sure to install or upgrade to minimum Docker version 19.03.
 * [Install Eclipse](https://www.eclipse.org/downloads/packages/release/)
-    * **Note:** Make sure to install or upgrade to mimimum Eclipse version 2019-09 R (4.13.0). 
+    * **Note:** Make sure to install or upgrade to mimimum Eclipse version 2019-09 R (4.13.0).
 
 ### Installing Codewind for Eclipse
 The Codewind installation pulls the following images that form the Codewind backend:
@@ -39,61 +41,63 @@ The Codewind installation pulls the following images that form the Codewind back
 The Codewind installation includes two parts:
 
 1. The Eclipse plug-in installs when you install Codewind from the [Eclipse Marketplace](https://marketplace.eclipse.org/content/codewind) or when you install by searching in the `Eclipse Extensions` view.
-2. The Codewind backend containers install after you click `Install`. Clicking `Install` downloads the Codewind backend containers, ~1GB. 
+2. The Codewind backend containers install after you click `Install`. Clicking `Install` downloads the Codewind backend containers, ~1GB.
 
 ### Configuring Codewind to use application stacks
 Configure Codewind to use Appsody templates so you can focus exclusively on your code. These templates include an Eclipse MicroProfile stack that you can use to follow this guide. Complete the following steps to select the Appsody templates:
 
-1. Click the `Codewind` tab. 
+1. Click the `Codewind` tab.
 2. Expand `Codewind` by clicking the drop-down arrow.
 3. Right-click `Local [Running]`.
-4. Select `Manage Template Sources...`. 
+4. Select `Manage Template Sources...`.
 5. Select `Appsody Stacks - incubator`.
-6. Click the `OK` button. 
+6. Click the `OK` button.
 
 You have now configured Codewind to use Appsody templates and can proceed to develop your microservice within Codewind.
 
-If your organization uses customized application stacks and has given you a URL that points to an `index.json` file, you can add it to Codewind: 
+If your organization uses customized application stacks and has given you a URL that points to an `index.json` file, you can add it to Codewind:
 
-1. Return to  `Codewind` and right-click `Local [Running]`. 
-2. Select `Manage Template Sources...`. 
+1. Return to  `Codewind` and right-click `Local [Running]`.
+2. Select `Manage Template Sources...`.
 3. Click the `Add...` button to add your URL.
-4. Add your URL in the `URL:` box in the pop up window and save your changes. 
+4. Add your URL in the `URL:` box in the pop up window and save your changes.
 
 ### Creating an Appsody project
-Appsody helps you develop containerized applications and removes the burden of managing the full software development stack. If you want more context about Appsody, visit the [Appsody welcome page](https://appsody.dev/docs). 
+Appsody helps you develop containerized applications and removes the burden of managing the full software development stack. If you want more context about Appsody, visit the [Appsody welcome page](https://appsody.dev/docs).
 
 1. Right-click `Local [Running]` under `Codewind` in the `Codewind` tab.
 2. Select `+ Create New Project...`
-    * **Note:** Make sure Docker is running. Otherwise, you get an error. 
-3. Name your project `appsody-calculator`. 
+    * **Note:** Make sure Docker is running. Otherwise, you get an error.
+3. Name your project `appsody-calculator`.
 4. Under `Template`, select `Appsody Open Liberty template`. 
     * If you don't see an Appsody template, select the `Manage Template Sources...` link at the end of the window.
-    * Select the `Appsody Stacks - appsodyhub` checkbox. 
+    * Select the `Appsody Stacks - appsodyhub` checkbox.
     * Click `OK`.
-    * The templates are refreshed, and the Appsody templates are available. 
+    * The templates are refreshed, and the Appsody templates are available.
 5. Click `Finish`.
     * To monitor your project's progress, right-click on your project, and select `Show Log Files`.
-    * Select `Show All`. Then a `Console` tab is displayed where you see your project's build logs. 
+    * Select `Show All`. Then a `Console` tab is displayed where you see your project's build logs.
 
-Your project is displayed in the `Local [Running]` section. The progress for creating your project is tracked next to the project's name. 
+Your project is displayed in the `Local [Running]` section. The progress for creating your project is tracked next to the project's name.
 
-Your project is complete when you see your project is running and its build is successful. 
+Your project is complete when you see your project is running and its build is successful.
 
 ### Accessing the application endpoint in a browser
-1. Return to your project under the Codewind tab. 
-2. Right-click your project and select `Open Application`. 
 
-Your application is now opened in a browser, showing the welcome to your Appsody microservice page. 
+1. Return to your project under the Codewind tab.
+2. Right-click your project and select `Open Application`.
+
+Your application is now opened in a browser, showing the welcome to your Appsody microservice page.
 
 ### Adding a REST service to your application
-1. Go to your project's workspace under the Project Explorer tab. 
-2. Navigate to `Java Resources->src/main/java->dev.appsody.starter`. 
-3. Right-click `dev.appsody.starter` and select `New->Class`.
-4. Create a Class file, name it `Calculator.java`, and select `Finish`. This file is your JAX-RS resource. 
-5. Populate the file with the following code and then **save** the file: 
 
-```
+1. Go to your project's workspace under the Project Explorer tab.
+2. Navigate to `Java Resources->src/main/java->dev.appsody.starter`.
+3. Right-click `dev.appsody.starter` and select `New->Class`.
+4. Create a Class file, name it `Calculator.java`, and select `Finish`. This file is your JAX-RS resource.
+5. Populate the file with the following code and then **save** the file:
+
+```java
 package dev.appsody.starter;
 
 import javax.ws.rs.core.Application;
@@ -111,43 +115,41 @@ public class Calculator extends Application {
     @GET
     @Path("/aboutme")
     @Produces(MediaType.TEXT_PLAIN)
-    public String aboutme(){
+    public String aboutme() {
         return "You can add (+), subtract (-), and multiply (*) with this simple calculator.";
     }
 
     @GET
     @Path("/{op}/{a}/{b}")
     @Produces(MediaType.TEXT_PLAIN)
-    public Response calculate(@PathParam("op") String op, @PathParam("a") String a, @PathParam("b") String b)
-    {
+    public Response calculate(@PathParam("op") String op, @PathParam("a") String a, @PathParam("b") String b) {
         int numA = Integer.parseInt(a);
         int numB = Integer.parseInt(b);
 
-      switch(op)
-      {
-          case "+":
-              return Response.ok(a + "+" + b + "=" + (Integer.toString((numA + numB)))).build();
+        switch (op) {
+            case "+":
+                return Response.ok(a + "+" + b + "=" + (Integer.toString((numA + numB)))).build();
 
-          case "-":
-              return Response.ok(a + "-" + b + "=" + (Integer.toString((numA - numB)))).build();
+            case "-":
+                return Response.ok(a + "-" + b + "=" + (Integer.toString((numA - numB)))).build();
 
-          case "*":
-              return Response.ok(a + "*" + b + "=" + (Integer.toString((numA * numB)))).build();
+            case "*":
+                return Response.ok(a + "*" + b + "=" + (Integer.toString((numA * numB)))).build();
 
-          default:
-              return Response.ok("Invalid operation. Please Try again").build();
-      }
+            default:
+                return Response.ok("Invalid operation. Please Try again").build();
+        }
     }
 }
 ```
-Any changes you make to your code are automatically built and re-deployed by Codewind and you can view them in your browser. 
+Any changes you make to your code are automatically built and re-deployed by Codewind and you can view them in your browser.
 
 ### Working with the example calculator microservice
-You now can work with the example calculator microservice. 
+You now can work with the example calculator microservice.
 
 * Use the port number you saw when you first opened the application.
-* Make sure to remove the `< >` symbol in the URL. 
-* `http://127.0.0.1:<port>/starter/calculator/aboutme` 
+* Make sure to remove the `< >` symbol in the URL.
+* `http://127.0.0.1:<port>/starter/calculator/aboutme`
 * You see the following response:
 
 ```
@@ -157,15 +159,15 @@ You can add (+), subtract (-), and multiply (*) with this simple calculator.
 You can try a few of the sample calculator functions:
 
 * `http://127.0.0.1:<port>/starter/calculator/{op}/{a}/{b}`, where you can input one of the available operations `(+, _, *)`, and an integer a, and an integer b.
-* So for `http://127.0.0.1:<port>/starter/calculator/+/10/3` you should see: `10+3=13`. 
+* So for `http://127.0.0.1:<port>/starter/calculator/+/10/3` you should see: `10+3=13`.
 
-## What you have learned 
+## What you have learned
 In this quick guide, you have learned to:
 1. Install Codewind on Eclipse
 2. Develop your own microservice using Codewind
 
-## Next Steps 
+## Next Steps
 See other quick guides to learn how to develop with Codewind:
 
 * [Codewind in VS Code](codewind-vscode-quick-guide.html)
-* [Codewind in Minikube](codewind-minikube-quick-guide.html) 
+* [Codewind in Minikube](codewind-minikube-quick-guide.html)

--- a/docs/_guides/codewind-vs-code-quick-guide.md
+++ b/docs/_guides/codewind-vs-code-quick-guide.md
@@ -2,7 +2,7 @@
 layout: guide
 summary_title: "Codewind in VS Code"
 title: "Getting Started with Codewind in VS Code"
-categories: guides 
+categories: guides
 guide_description: "Take advantage of Codewind's tools to help build high quality cloud native applications regardless of which IDE or language you use."
 permalink: codewind-vscode-quick-guide
 duration: 5 minutes
@@ -10,24 +10,24 @@ keywords: Codewind, VS Code, microservice
 ---
 
 ## Objectives
-* Install Visual Studio Code (VS Code) and Codewind 
+* Install Visual Studio Code (VS Code) and Codewind
 * Develop a simple microservice, using Eclipse Codewind on VS Code
 
-## Overview 
-Eclipse Codewind provides the ability to create application projects from `Application Stacks` that your company has built, enabling developers to focus on their code and not infrastructure and Kubernetes. Application deployments to Kubernetes occur via pipelines when developers commit their local code to the correct Git repos Kabanero is managing via webhooks.    
+## Overview
+Eclipse Codewind provides the ability to create application projects from `Application Stacks` that your company has built, enabling developers to focus on their code and not infrastructure and Kubernetes. Application deployments to Kubernetes occur via pipelines when developers commit their local code to the correct Git repos Kabanero is managing via webhooks.
 
 Eclipse Codewind provides the ability to create projects based on a variety of different template types.  These include IBM Cloud starters, OpenShift Do (odo), and Appsody templates. Today, there are templates for: IBM Cloud Starters, odo, Eclipse MicroProfile/Java EE, Springboot, Node.js, Node.js with Express, and Node.js with Loopback.
 
 ## Developing with VS Code
 You can use Codewind for VS Code to develop and debug your containerized projects from within VS Code using the workflow you already use today.
 
-### Prerequisite 
+### Prerequisite
 Before you can develop a microservice with VS Code, you need to:
 
-* [Install Docker](https://docs.docker.com/install/) 
-    * **Note:** Make sure to install or upgrade to minimum Docker version 19.03. 
+* [Install Docker](https://docs.docker.com/install/)
+    * **Note:** Make sure to install or upgrade to minimum Docker version 19.03.
 * [Install VS Code](https://code.visualstudio.com/download)
- 
+
 ### Installing Codewind for VS Code
 The Codewind installation pulls the following images that form the Codewind backend:
 
@@ -36,58 +36,58 @@ The Codewind installation pulls the following images that form the Codewind back
 
 The Codewind installation includes two parts:
 
-1. The VS Code extension installs when you install Codewind from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=IBM.codewind) and click `Install`. 
-    * Or, go to `View->Extensions`, search for Codewind, and click `Install`. 
-2. The Codewind backend containers install after you click `Install` when you are prompted. Clicking `Install` downloads the Codewind backend containers, ~1GB. 
-    * **Optional:** If you don’t click `Install` when the notification window first appears, you can access the notification again. Go to `View->Explorer`. Then click `Codewind` and hover the cursor over `Codewind` where there is a switch to turn Codewind on or off. Click the switch so that it is `On`. The notification window is displayed. 
+1. The VS Code extension installs when you install Codewind from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=IBM.codewind) and click `Install`.
+    * Or, go to `View->Extensions`, search for Codewind, and click `Install`.
+2. The Codewind backend containers install after you click `Install` when you are prompted. Clicking `Install` downloads the Codewind backend containers, ~1GB.
+    * **Optional:** If you don’t click `Install` when the notification window first appears, you can access the notification again. Go to `View->Explorer`. Then click `Codewind` and hover the cursor over `Codewind` where there is a switch to turn Codewind on or off. Click the switch so that it is `On`. The notification window is displayed.
 
-### Configuring Codewind to use application stacks 
+### Configuring Codewind to use application stacks
 Configure Codewind to use Appsody templates so you can focus exclusively on your code. These templates include an Eclipse MicroProfile stack that you can use to follow this guide. Complete the following steps to select the Appsody templates:
 
-1. Under the Explorer pane, select `Codewind`. 
+1. Under the Explorer pane, select `Codewind`.
 2. Right-click `Local`.
-3. Select `Template Source Manager`. 
-4. Enable `Appsody Stacks - incubator`. 
+3. Select `Template Source Manager`.
+4. Enable `Appsody Stacks - incubator`.
 
 You have now configured Codewind to use Appsody templates and can proceed to develop your microservice within Codewind.
 
-If your organization uses customized application stacks and has given you a URL that points to an `index.json` file, you can add it to Codewind: 
+If your organization uses customized application stacks and has given you a URL that points to an `index.json` file, you can add it to Codewind:
 
-1. Return to  `Codewind` and right-click `Local`. 
-2. Select `Template Source Manager`. 
+1. Return to  `Codewind` and right-click `Local`.
+2. Select `Template Source Manager`.
 3. Click the `Add New +` button to add your URL.
-4. Add your URL in the pop up window and save your changes. 
+4. Add your URL in the pop up window and save your changes.
 
 ### Creating an Appsody project
-Throughout the application lifestyle, Appsody helps you develop containerized applications and leverage containers curated for your usage. If you want more context about Appsody, visit the [Appsody welcome page](https://appsody.dev/docs). 
+Throughout the application lifestyle, Appsody helps you develop containerized applications and leverage containers curated for your usage. If you want more context about Appsody, visit the [Appsody welcome page](https://appsody.dev/docs).
 
 1. Under the Explorer pane, select `Codewind`.
-2. Expand `Codewind` by clicking the drop-down arrow. 
+2. Expand `Codewind` by clicking the drop-down arrow.
 3. Hover over the `Projects` entry underneath Codewind in the Explorer pane, and press the `+` icon to create a project.
-    * **Note:** Make sure Docker is running. Otherwise, you get an error. 
-4. Choose the `Open Liberty (Default templates)`. 
+    * **Note:** Make sure Docker is running. Otherwise, you get an error.
+4. Choose the `Open Liberty (Default templates)`.
 5. Name your project `appsody-calculator`.
-    * If you don't see Appsody templates, find and select `Template Source Manager` and enable `Appsody Stacks - appsodyhub`. 
-    * The templates are refreshed, and the Appsody templates are available. 
-6. Press `Enter`. 
-    * To monitor your project's progress, right-click your project, and select `Show all logs`. Then an `Output` tab is displayed where you see your project's build logs. 
+    * If you don't see Appsody templates, find and select `Template Source Manager` and enable `Appsody Stacks - appsodyhub`.
+    * The templates are refreshed, and the Appsody templates are available.
+6. Press `Enter`.
+    * To monitor your project's progress, right-click your project, and select `Show all logs`. Then an `Output` tab is displayed where you see your project's build logs.
 
-Your project is complete when you see your application status is running and your build status is successful. 
+Your project is complete when you see your application status is running and your build status is successful.
 
 ### Accessing the application endpoint in a browser
-1. Return to your project under the Explorer pane. 
-2. Select the Open App icon next to your project's name, or right-click your project and select `Open App`. 
+1. Return to your project under the Explorer pane.
+2. Select the Open App icon next to your project's name, or right-click your project and select `Open App`.
 
 Your application is now opened in a browser, showing the welcome to your Appsody microservice page.
 
 ### Adding a REST service to your application
- 1. Go to your project's workspace under the Explorer tab. 
+ 1. Go to your project's workspace under the Explorer tab.
  2. Navigate to `src->main->java->dev->appsody->starter`.
  3. Right-click `starter` and select `New File`.
- 4. Create a file, name it `Calculator.java`, and press `Enter`. This file is your JAX-RS resource. 
- 5. Populate the file with the following code and then **save** the file: 
+ 4. Create a file, name it `Calculator.java`, and press `Enter`. This file is your JAX-RS resource.
+ 5. Populate the file with the following code and then **save** the file:
 
-```
+```java
 package dev.appsody.starter;
 
 import javax.ws.rs.core.Application;
@@ -105,62 +105,61 @@ public class Calculator extends Application {
     @GET
     @Path("/aboutme")
     @Produces(MediaType.TEXT_PLAIN)
-    public String aboutme(){
+    public String aboutme() {
         return "You can add (+), subtract (-), and multiply (*) with this simple calculator.";
     }
 
     @GET
     @Path("/{op}/{a}/{b}")
     @Produces(MediaType.TEXT_PLAIN)
-    public Response calculate(@PathParam("op") String op, @PathParam("a") String a, @PathParam("b") String b)
-    {
+    public Response calculate(@PathParam("op") String op, @PathParam("a") String a, @PathParam("b") String b) {
         int numA = Integer.parseInt(a);
         int numB = Integer.parseInt(b);
 
-      switch(op)
-      {
-          case "+":
-              return Response.ok(a + "+" + b + "=" + (Integer.toString((numA + numB)))).build();
+        switch (op) {
+            case "+":
+                return Response.ok(a + "+" + b + "=" + (Integer.toString((numA + numB)))).build();
 
-          case "-":
-              return Response.ok(a + "-" + b + "=" + (Integer.toString((numA - numB)))).build();
+            case "-":
+                return Response.ok(a + "-" + b + "=" + (Integer.toString((numA - numB)))).build();
 
-          case "*":
-              return Response.ok(a + "*" + b + "=" + (Integer.toString((numA * numB)))).build();
+            case "*":
+                return Response.ok(a + "*" + b + "=" + (Integer.toString((numA * numB)))).build();
 
-          default:
-              return Response.ok("Invalid operation. Please Try again").build();
-      }
+            default:
+                return Response.ok("Invalid operation. Please Try again").build();
+        }
     }
 }
 ```
-Any changes you make to your code are automatically built and re-deployed by Codewind and you can view them in your browser.  
+
+Any changes you make to your code are automatically built and re-deployed by Codewind and you can view them in your browser.
 
 ### Working with the example calculator microservice
 You now can work with the example calculator microservice.
 
 1. Use the port number you saw when you first opened the application.
-2. Make sure to remove the `< >` symbol in the URL. 
-3. `http://127.0.0.1:<port>/starter/calculator/aboutme` 
+2. Make sure to remove the `< >` symbol in the URL.
+3. `http://127.0.0.1:<port>/starter/calculator/aboutme`
 4. You see the following response:
 
 ```
 You can add (+), subtract (-), and multiply (*) with this simple calculator.
 ```
 
-You can also try a few of the sample calculator functions: 
+You can also try a few of the sample calculator functions:
 
 * `http://127.0.0.1:<port>/starter/calculator/{op}/{a}/{b}`, where you can input one of the available operations `(+, _, *)`, and an integer a, and an integer b.
 * So for `http://127.0.0.1:<port>/starter/calculator/+/10/3` you see: `10+3=13`.
 
-## What you have learned 
+## What you have learned
 Now that you have completed this quick guide, you have learned to:
 
 1. Install Codewind on VS Code
 2. Develop your own microservice using Codewind
 
-## Next Steps 
+## Next Steps
 See other quick guides to learn how to develop with Codewind:
 
-* [Codewind in Eclipse](codewind-eclipse-quick-guide.html) 
-* [Codewind in Minikube](codewind-minikube-quick-guide.html) 
+* [Codewind in Eclipse](codewind-eclipse-quick-guide.html)
+* [Codewind in Minikube](codewind-minikube-quick-guide.html)


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What does this PR do ?

- Uses a Java code block in the 2 guides, and makes indentation of code consistent. 

- Uses json and yaml code blocks in 2 docs files (`templates` and `referencing files`). 

This benefit of these changes is aesthetic and in making it easier for a user to follow and then copy.

e.g. before:

<img width="1315" alt="Screenshot 2020-05-13 at 12 08 07" src="https://user-images.githubusercontent.com/31372187/81805568-ffb19700-9512-11ea-8c03-bae29937246a.png">

after:

<img width="1324" alt="Screenshot 2020-05-13 at 12 08 23" src="https://user-images.githubusercontent.com/31372187/81805578-05a77800-9513-11ea-849d-b7ac7b5c3a5c.png">


Also removes whitespace from all files modified.
