### PR TITLE
Remove duplicate header in guides

### DIFF
--- a/docs/_guides/codewind-eclipse-quick-guide.md
+++ b/docs/_guides/codewind-eclipse-quick-guide.md
@@ -1,14 +1,13 @@
 ---
 layout: guide
-title: "Codewind in Eclipse"
-categories: guides 
+summary_title: "Codewind in Eclipse"
+title: "Getting Started with Codewind in Eclipse"
+categories: guides
 guide_description: "Take advantage of Codewind's tools to help build high quality cloud native applications regardless of which IDE or language you use."
 permalink: codewind-eclipse-quick-guide
 duration: 5 minutes
 tags: Codewind, Eclipse, microservice
 ---
-
-# Getting Started with Codewind in Eclipse 
 
 ## Objectives
 * Install Eclipse and Codewind 

--- a/docs/_guides/codewind-vs-code-quick-guide.md
+++ b/docs/_guides/codewind-vs-code-quick-guide.md
@@ -1,14 +1,13 @@
 ---
 layout: guide
-title: "Codewind in VS Code"
+summary_title: "Codewind in VS Code"
+title: "Getting Started with Codewind in VS Code"
 categories: guides 
 guide_description: "Take advantage of Codewind's tools to help build high quality cloud native applications regardless of which IDE or language you use."
 permalink: codewind-vscode-quick-guide
 duration: 5 minutes
 keywords: Codewind, VS Code, microservice
 ---
-
-# Getting Started with Codewind in VS Code
 
 ## Objectives
 * Install Visual Studio Code (VS Code) and Codewind 

--- a/docs/_layouts/guides.html
+++ b/docs/_layouts/guides.html
@@ -17,7 +17,7 @@
 
                         <div class="guides-post-content guides-content">
                             <h2 class="guides-post-title"><a href="{{ post.url | relative_url }}"
-                                    class="guides-post-title-link">{{ post.title | escape }}</a></h2>
+                                    class="guides-post-title-link">{{ post.summary_title | escape }}</a></h2>
                             <p class="guides-post-date-mobile d-sm-block d-md-none">{{ post.date | date: date_format }}
                             </p>
                             <p class="guides-post-paragraph">


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Removes duplicate title from guides. 

Instead uses a summary title for the guides index page, and the main title for the page itself.

## Which issue(s) does this PR fix ?

Part of https://github.com/eclipse/codewind/issues/2929

