### PR TITLE
Update docs for 0.12.0 Che/Codewind

### DIFF
--- a/docs/_documentations/che-createcodewindworkspace.md
+++ b/docs/_documentations/che-createcodewindworkspace.md
@@ -17,7 +17,7 @@ Codewind includes a ready-to-use devfile with its plug-ins. Complete the followi
 2. Go to **Workspaces** and click **Add Workspace**.
 3. Click **Import Devfile**.
 4. From **Source**, click **YAML**.
-5. Go to the link [codewind-che-plugin/0.11.0/devfile.yaml](https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.11.0/devfiles/0.11.0/devfile.yaml) and copy and paste the contents into the YAML text box in your Che workspace.
+5. Go to the link [codewind-che-plugin/0.12.0/devfile.yaml](https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.12.0/devfiles/0.12.0/devfile.yaml) and copy and paste the contents into the YAML text box in your Che workspace.
 6. Click **Create & Open**.
 
 For more sample devfiles, see [`codewind-templates/devfiles/`](https://github.com/kabanero-io/codewind-templates/tree/master/devfiles).

--- a/docs/_documentations/che-installinfo.md
+++ b/docs/_documentations/che-installinfo.md
@@ -22,7 +22,7 @@ Install Che to use with Codewind or prepare to use Codewind with an existing Che
    - Both Eclipse Che and Eclipse Codewind host Docker images at these locations.
    - Many clusters have image policies that control which registries you can use to pull images. Check your cluster documentation and ensure that the cluster image pull policies permit both of these registries.
 3. Set up the ClusterRole for Codewind:
-`kubectl apply -f https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.11.0/setup/install_che/codewind-clusterrole.yaml`
+`kubectl apply -f https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.12.0/setup/install_che/codewind-clusterrole.yaml`
 
 ## Installing Che with chectl
 
@@ -31,7 +31,7 @@ Install Eclipse Che with HTTPS so that Codewind functions properly. See the [Ins
 ### Installing Che
 The fastest way to install Eclipse Che for Codewind is to use the `chectl` CLI. To install the `chectl` CLI tool, see [Installing the chectl management tool](https://www.eclipse.org/che/docs/che-7/installing-the-chectl-management-tool/).
 
-After you install `chectl`, download the [codewind-checluster.yaml](https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.11.0/setup/install_che/che-operator/codewind-checluster.yaml) file.
+After you install `chectl`, download the [codewind-checluster.yaml](https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.12.0/setup/install_che/che-operator/codewind-checluster.yaml) file.
  - You can modify this file, but leave the `spec.server.cheWorkspaceClusterRole` field set to `eclipse-codewind` and the `spec.storage.preCreateSubPaths` field set to `true`.
 
 **Installing on OpenShift:**
@@ -70,7 +70,7 @@ If you already have a Che installation with TLS, you can update it for Codewind.
 
 Run the following command, where `$NAMESPACE` is the namespace that your Che workspaces run in. By default, this namespace is `che`.
 ```
-$ kubectl apply -f https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.11.0/setup/install_che/codewind-clusterrole.yaml -n $NAMESPACE
+$ kubectl apply -f https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.12.0/setup/install_che/codewind-clusterrole.yaml -n $NAMESPACE
 ```
 
 ## Adding certificates for Che to your browser

--- a/docs/_documentations/remote-deploying-codewind.md
+++ b/docs/_documentations/remote-deploying-codewind.md
@@ -47,7 +47,7 @@ The Codewind operator helps with the deployment of Codewind instances in an Open
 
 Clone the Codewind operator repository, for example: 
 
-`$ git clone https://github.com/eclipse/codewind-operator -b 0.11.0`
+`$ git clone https://github.com/eclipse/codewind-operator -b 0.12.0`
 
 For more detailed information about the Codewind operator and the install process, see the [Codewind operator readme](https://github.com/eclipse/codewind-operator/blob/master/README.md).
 


### PR DESCRIPTION
Updates the Codewind Che plugin links in the doc to use the 0.12.0 links.