### PR TITLE
Removing broken link

### DIFF
--- a/docs/_guides/codewind-vs-code-quick-guide.md
+++ b/docs/_guides/codewind-vs-code-quick-guide.md
@@ -162,4 +162,3 @@ Now that you have completed this quick guide, you have learned to:
 See other quick guides to learn how to develop with Codewind:
 
 * [Codewind in Eclipse](codewind-eclipse-quick-guide.html)
-* [Codewind in Minikube](codewind-minikube-quick-guide.html)


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

Removing broken link. PR for https://github.com/eclipse/codewind/issues/2941.

The file `codewind-minikube-quick-guide.html` is not currently merged. We can add this link after the file is merged.