### PR TITLE
Fix extra spacing above linked section

### DIFF
--- a/docs/css/docs.css
+++ b/docs/css/docs.css
@@ -37,7 +37,7 @@ code {
 :target:before {
     content: "";
     display: block;
-    margin-top: -115x;
+    margin-top: -115px;
     height: 115px;
     width: 1px;
 }
@@ -88,12 +88,10 @@ code {
 
 /* Separators */
 .cw-sidebar-separator-title {
-    
     height: 35px;
 }
 
 .cw-sidebar-separator {
-    
     height: 25px;
 }
 
@@ -248,7 +246,7 @@ code {
 	    position: absolute;
 	    top: -15px;
 	}
-	
+
 	#sidebar-container {
         padding-top: 101px;
     }
@@ -266,8 +264,6 @@ code {
         width: 100vw;
         	min-height: 0;
     }
-    
-    
 }
 
 /* code formatter overrides for accessibility */


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Fixes the bug where extra space was being added above a linked section. 

This was caused by a typo in the css class added to stop the navbar covering a linked element. 

Removes a few lines of whitespace in the file also.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2771
