### PR TITLE
Rename gettingstarted.md to gettingstarted-overview

### DIFF
--- a/docs/_documentations/gettingstarted-overview.md
+++ b/docs/_documentations/gettingstarted-overview.md
@@ -1,0 +1,21 @@
+---
+layout: docs
+title: Getting Started
+description: Getting Started
+keywords: install, Codewind, remote, hosted, cloud, standalone, get started, getting started, IDE, VS Code, Eclipse, Eclipse Che, IntelliJ
+duration: 1 minute
+permalink: gettingstarted
+type: document
+---
+
+# Getting Started with Codewind
+
+**You can try out Codewind by using the local configuration**. For local use of Codewind, and also the pre-requisite steps for **remote use of Codewind**, select from:
+
+* [VS Code](./vsc-getting-started.html)
+* [Eclipse](./eclipse-getting-started.html) 
+* [IntelliJ](./intellij-getting-started.html)
+
+**Codewind as a hosted application in the cloud** If you want to go straight to using codewind as a hosted application in the cloud, select the [Eclipse Che instructions](./eclipseche-codewind-overview.html)
+
+**The different configurations of Codewind** To find out about the different ways of using Codewind - locally, remotely, or as an application hosted on the cloud - see [Codewind Architecture](./overview.html#architecture).


### PR DESCRIPTION
Ready for redirection

Signed-off-by: MelHopper <melanieh@uk.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Renames the existing getting started page: 
gettingstarted.md -> gettingstarted-overview.md
so that the current content remains in the Getting Started section of the ToC, to be reworked or replaced at a later date, but so that traffic coming into gettingstarted.html can now be redirected to the new Content Landing Page. 

## Which issue(s) does this PR fix ?
Remove the existing getting started page and redirect to the overview #2591

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2591

## Does this PR require a documentation change ?
Yes

## Any special notes for your reviewer ?
