### PR TITLE
Bring IDE images in front of city on home page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,14 @@ home: true
 
 <!-- Hero -->
 <div id="hero-body">
+    <div id="hero-city">
+        <img alt="city background" title="city background" id="hero-city-svg" src="images/index/hero-city.svg" /><img
+            alt="city background" title="city background" id="hero-city-svg-2" src="images/index/hero-city.svg" /><img
+            alt="city background" title="city background" id="hero-city-svg-3" src="images/index/hero-city.svg" />
+    </div>
+    <div id="hero-turbine">
+        <img alt="turbine image" title="turbine image" id="hero-turbine-svg" src="images/index/hero-turbines.svg" />
+    </div>
     <div id="hero-main">
         <div id="hero-main-text">
             <div id="hero-main-title"><span>Eclipse Code</span>wind</div>
@@ -17,31 +25,26 @@ home: true
                 templates
                 or samples, or pull in your applications and let Codewind get them cloud ready. </div>
             <aside aria-label="about Longboards">
-            	<button onclick="location.href='gettingstarted.html'"  type="button" id="get-started-button" class="btn">Get started</button>
-        		</aside>
+                <button onclick="location.href='gettingstarted.html'" type="button" id="get-started-button"
+                    class="btn">Get started</button>
+            </aside>
         </div>
 
         <div id="hero-main-hero">
             <div id="hero-main-hero-vscode">
                 <div>VS Code</div>
-                <div><img alt="vscode ide"  title="vscode ide" src="images/index/hero-vscode-noshadow.png"></div>
+                <div style="z-index:1"><img alt="vscode ide" title="vscode ide"
+                        src="images/index/hero-vscode-noshadow.png"></div>
             </div>
             <div id="hero-main-hero-eclipse">
                 <div>Eclipse</div>
-                <div><img alt="eclipse ide"  title="eclipse ide" src="images/index/hero-eclipse-noshadow.png"></div>
+                <div><img alt="eclipse ide" title="eclipse ide" src="images/index/hero-eclipse-noshadow.png"></div>
             </div>
             <div id="hero-main-hero-che">
                 <div class="text-right">Eclipse Che</div>
-                <div><img alt="che ide"  title="che ide" src="images/index/hero-che-noshadow.png"></div>
+                <div><img alt="che ide" title="che ide" src="images/index/hero-che-noshadow.png"></div>
             </div>
         </div>
-    </div>
-
-    <div id="hero-city">
-        <img alt="city background"   title="city background" id="hero-city-svg" src="images/index/hero-city.svg" /><img alt="city background"   title="city background" id="hero-city-svg-2" src="images/index/hero-city.svg" /><img alt="city background"   title="city background" id="hero-city-svg-3" src="images/index/hero-city.svg" />
-    </div>
-    <div id="hero-turbine">
-            <img alt="turbine image"   title="turbine image" id="hero-turbine-svg" src="images/index/hero-turbines.svg" />
     </div>
 </div>
 
@@ -146,8 +149,8 @@ home: true
             <img alt="monitoring icon"  title="monitoring icon" src="images/index/monitoring-icon.svg" class="cw-logo" />
         </div>
     </div>
-    
-    
+
+
 </div>
 
 <!-- key features row END -->
@@ -157,7 +160,7 @@ home: true
 		<div class="p-md-5">
 		<span class="cw-youtube-view-font">View the demo</span>
 			<div class="embed-responsive embed-responsive-16by9">
-			    
+
 				<iframe width="1280" height="720" title="Codewind youtube video" src="https://www.youtube.com/embed/mjADP2_4FBg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 			</div>
 		</div>


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Brings the images of the IDEs in front the the city-scape on the home page. 

As absolute position is used for the city, z-index had no effect, so instead arranged the HTML to render the city and Turbine before the images.

### Before 

<img width="1680" alt="Screenshot 2020-05-21 at 11 44 15" src="https://user-images.githubusercontent.com/31372187/82551622-71fc2a00-9b58-11ea-9c0b-3a615d8b4f7c.png">

### After

<img width="1680" alt="Screenshot 2020-05-21 at 11 44 20" src="https://user-images.githubusercontent.com/31372187/82551635-76284780-9b58-11ea-8e6a-b649d0e25e15.png">

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2451
