### PR TITLE
Fixing broken link, style edits

### DIFF
--- a/docs/_documentations/vsc-getting-started.md
+++ b/docs/_documentations/vsc-getting-started.md
@@ -26,7 +26,7 @@ Select your IDE to get started:
 
 **Codewind on Eclipse Che** If you want to go straight to using Codewind as a hosted application in the cloud, follow [these instructions](./che-installinfo.html).
 
-**Using Codewind Remotely** To use Codewind remotely, first [follow the step to install Codewind locally](#installing-codewind-for-vs-code). By [using Codewind remotely](./remote-codewind-overview.html), Codewind is configured for making code changes on your local IDE but building and running your application in the cloud. Once you have installed Codewind remotely, you can proceed to either:
+**Using Codewind remotely** To use Codewind remotely, first [follow the step to install Codewind locally](#installing-codewind-for-vs-code). By [using Codewind remotely](./remote-codewind-overview.html), Codewind is configured for making code changes on your local IDE but building and running your application in the cloud. Once you have installed Codewind remotely, you can proceed to either:
 
 1. Deploy Codewind to your cloud if not already done so by you or a sysadmin/DevOps engineer. See tutorial [Deploying Codewind Remotely](./remote-deploying-codewind.html).
 2. Connect your Codewind extension of your local desktop IDE to Codewind in your cloud by following the tutorial [Using Codewind Remotely](./remote-codewind-overview.html).

--- a/docs/_documentations/vsc-getting-started.md
+++ b/docs/_documentations/vsc-getting-started.md
@@ -10,7 +10,7 @@ order: 1
 ---
 # Getting Started with Codewind
 
-There are three ways of using Codewind - locally, remotely or as a hosted application on the cloud. To get started, **you can try out Codewind by using the local configuration**. In this configuration, you create, develop, build and run your containerised applications on your local machine using your local IDE.
+There are three ways of using Codewind - locally, remotely or as a hosted application on the cloud. To get started, you can try out Codewind by using the local configuration. In this configuration, you create, develop, build and run your containerised applications on your local machine using your local IDE.
 
 Follow the instructions to get started with using Codewind locally. This will guide you through:
 
@@ -26,7 +26,7 @@ Select your IDE to get started:
 
 **Codewind on Eclipse Che** If you want to go straight to using Codewind as a hosted application in the cloud, follow [these instructions](./che-installinfo.html).
 
-**Using Codewind Remotely** If you want to use Codewind remotely, **you must first [follow the step to install Codewind locally](##installing-codewind-for-vs-code)**. By [using Codewind remotely](./remote-codewind-overview.html), Codewind is configured for making code changes on your local IDE but building and running your application in the cloud. Once you have installed Codewind remotely, you can proceed to either:
+**Using Codewind Remotely** To use Codewind remotely, first [follow the step to install Codewind locally](#installing-codewind-for-vs-code). By [using Codewind remotely](./remote-codewind-overview.html), Codewind is configured for making code changes on your local IDE but building and running your application in the cloud. Once you have installed Codewind remotely, you can proceed to either:
 
 1. Deploy Codewind to your cloud if not already done so by you or a sysadmin/DevOps engineer. See tutorial [Deploying Codewind Remotely](./remote-deploying-codewind.html).
 2. Connect your Codewind extension of your local desktop IDE to Codewind in your cloud by following the tutorial [Using Codewind Remotely](./remote-codewind-overview.html).


### PR DESCRIPTION
- Fixing broken link. The link doesn't appear to work if two `##` are present.
- Using bold text like a heading, such as on line 27, can help it stand out. However, using it for emphasis might diminish its meaning since we also use bold for button names and the like. I propose that we remove bold for emphasis while keeping bold for headings and button names.