### PR TITLE
Improve the design of the "Guides" page

### DIFF
--- a/docs/_guides/codewind-eclipse-quick-guide.md
+++ b/docs/_guides/codewind-eclipse-quick-guide.md
@@ -3,10 +3,12 @@ layout: guide
 summary_title: "Codewind in Eclipse"
 title: "Getting Started with Codewind in Eclipse"
 categories: guides
-guide_description: "Take advantage of Codewind's tools to help build high quality cloud native applications regardless of which IDE or language you use."
+description: "Take advantage of Codewind's tools to help build high quality cloud native applications regardless of which IDE or language you use."
 permalink: codewind-eclipse-quick-guide.html
 duration: 5 minutes
 tags: Codewind, Eclipse, microservice
+image: "https://cdn.freebiesupply.com/logos/large/2x/eclipse-11-logo-png-transparent.png"
+objectives: ["Install Eclipse and Codewind", "Develop a simple microservice, using Eclipse Codewind in Eclipse"]
 ---
 
 # Getting Started with Codewind in Eclipse

--- a/docs/_guides/codewind-vs-code-quick-guide.md
+++ b/docs/_guides/codewind-vs-code-quick-guide.md
@@ -3,10 +3,12 @@ layout: guide
 summary_title: "Codewind in VS Code"
 title: "Getting Started with Codewind in VS Code"
 categories: guides
-guide_description: "Take advantage of Codewind's tools to help build high quality cloud native applications regardless of which IDE or language you use."
+description: "Take advantage of Codewind's tools to help build high quality cloud native applications regardless of which IDE or language you use."
 permalink: codewind-vscode-quick-guide.html
 duration: 5 minutes
 keywords: Codewind, VS Code, microservice
+image: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Visual_Studio_Code_1.35_icon.svg/1200px-Visual_Studio_Code_1.35_icon.svg.png"
+objectives: ["Install Visual Studio Code (VS Code) and Codewind", "Develop a simple microservice, using Eclipse Codewind on VS Code"]
 ---
 
 ## Objectives

--- a/docs/_layouts/guides.html
+++ b/docs/_layouts/guides.html
@@ -52,7 +52,7 @@
                             <h5 class="guides-objective-header">Objectives</h5>
                             <ul class="guides-objective-list">
                                 {% for objective in post.objectives %}
-                                    <li>{{ objective }}</li> 
+                                    <li class="objective-item">{{ objective }}</li> 
                                 {% endfor %}
                             </ul>
                             

--- a/docs/_layouts/guides.html
+++ b/docs/_layouts/guides.html
@@ -35,7 +35,7 @@
                     </div> -->
 
                     <div class="media">
-                        <img src="{{ post.image }}" class="align-self-start mr-3" alt="...">
+                        <img src="{{ post.image }}" class="align-self-start guide-image" alt="...">
                         <div class="media-body">
                             <h5 class="mt-0">
                                 <a href="{{ post.url | relative_url }}" class="guides-post-title-link">

--- a/docs/_layouts/guides.html
+++ b/docs/_layouts/guides.html
@@ -13,7 +13,7 @@
                 {% for post in site.guides reversed %}
 
                 <div class="row guides-post-row">
-                    <div class="guides-post-column col">
+                    <!-- <div class="guides-post-column col">
 
                         <div class="guides-post-content guides-content">
                             <h2 class="guides-post-title"><a href="{{ post.url | relative_url }}"
@@ -31,6 +31,31 @@
                             <div class="read-more-link-container ">
                                 <a href="{{ post.url | relative_url }}" class="read-more-link">Read more</a>
                             </div>
+                        </div>
+                    </div> -->
+
+                    <div class="media">
+                        <img src="{{ post.image }}" class="align-self-start mr-3" alt="...">
+                        <div class="media-body">
+                            <h5 class="mt-0">
+                                <a href="{{ post.url | relative_url }}" class="guides-post-title-link">
+                                    {{ post.summary_title | escape }}
+                                </a>
+                            </h5>
+                            <p>
+                                {% if post.description %}
+                                {{ post.description }}
+                                {% else %}
+                                {{ post.content | strip_html | truncatewords: 60 }}
+                                {% endif %}
+                            </p>
+                            <h5 class="guides-objective-header">Objectives</h5>
+                            <ul class="guides-objective-list">
+                                {% for objective in post.objectives %}
+                                    <li>{{ objective }}</li> 
+                                {% endfor %}
+                            </ul>
+                            
                         </div>
                     </div>
                 </div>

--- a/docs/css/docs.css
+++ b/docs/css/docs.css
@@ -156,9 +156,10 @@ code {
 }
 .list-group > .list-group-item {
     border-bottom: 1px solid #d8d8d8;
-    border-top: 1px solid #d8d8d8;
+    border: 1px solid #d8d8d8;
     font-size: 18px;
     font-weight: 400;
+    margin-bottom: 20px;
 }
 
 .cw-extlink:after {

--- a/docs/css/docs.css
+++ b/docs/css/docs.css
@@ -159,7 +159,6 @@ code {
     border: 1px solid #d8d8d8;
     font-size: 18px;
     font-weight: 400;
-    margin-bottom: 20px;
 }
 
 .cw-extlink:after {

--- a/docs/css/guides.css
+++ b/docs/css/guides.css
@@ -91,5 +91,6 @@
     margin-bottom: .5em;
 }
 
-.guides-objective-list {
+.objective-item {
+    margin-bottom: 20px;
 }

--- a/docs/css/guides.css
+++ b/docs/css/guides.css
@@ -14,6 +14,7 @@
     margin: 0 auto;
     padding-left: 20px;
     padding-right: 20px;
+    
 
     @media (max-width: 991.98px) {
         width: 100%;
@@ -32,6 +33,9 @@
 
 .guides-post-row {
     width: 100%;
+    background-color: #f7f7f7;
+    padding: 20px;
+    margin: 15px;
 }
 
 .guides-post-content {
@@ -57,7 +61,7 @@
 .guides-post-title-link {
     font-family: 'IBM Plex Sans';
     font-size: 30px;
-    color: #292828;
+    color: #0073ba;
     transition: color .2s;
 }
 
@@ -77,4 +81,15 @@
 .guides-content{
     background-color:#f3f5f7 !important;
     margin: 20px 0 20px 0;
+}
+
+.mr-3 {
+    height: 64px;
+}
+
+.guides-objective-header {
+    margin-bottom: .5em;
+}
+
+.guides-objective-list {
 }

--- a/docs/css/guides.css
+++ b/docs/css/guides.css
@@ -34,7 +34,7 @@
 .guides-post-row {
     width: 100%;
     background-color: #f7f7f7;
-    padding: 20px;
+    padding: 40px;
     margin: 15px;
 }
 
@@ -83,14 +83,18 @@
     margin: 20px 0 20px 0;
 }
 
-.mr-3 {
-    height: 64px;
-}
-
 .guides-objective-header {
     margin-bottom: .5em;
 }
 
+.guide-image {
+    height: 64px;
+}
+
+.media-body {
+    margin-left: 15px;
+}
+
 .objective-item {
-    margin-bottom: 20px;
+    margin-bottom: .25em;
 }

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -461,6 +461,7 @@ code {
     color: #fff;
     height: 225px;
     align-items: center;
+    margin-top: 35px;
 }
 
 .cw-footer-col {


### PR DESCRIPTION
Signed-off-by: Alif Munim <alif.munim@ryerson.ca>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
* Make guide titles blue to make their interactivity more apparent
* Add objective and image metadata to the guide markdown files
* Access and display objective and image metadata on each guide preview
* Remove "read more" link to eliminate redundancy
* Adjust spacing

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2929
_(Individual guide pages referenced in the issue not yet fixed.)_

## Does this PR require a documentation change ?
Not as far as I am aware.

## Any special notes for your reviewer ?
None.