### PR TITLE
Remove duplicate guide title

### DIFF
--- a/docs/_guides/codewind-eclipse-quick-guide.md
+++ b/docs/_guides/codewind-eclipse-quick-guide.md
@@ -9,8 +9,6 @@ duration: 5 minutes
 tags: Codewind, Eclipse, microservice
 ---
 
-# Getting Started with Codewind in Eclipse
-
 ## Objectives
 * Install Eclipse and Codewind
 * Develop a simple microservice, using Eclipse Codewind in Eclipse


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Noticed a duplicate title in the Eclipse quick guide, this PR removes it.

<img width="1619" alt="Screenshot 2020-06-03 at 13 19 21" src="https://user-images.githubusercontent.com/31372187/83635944-fd37df80-a59c-11ea-8518-48ece294a43f.png">
