### PR TITLE
Removing numbering from topics in Remote section until a fix is created

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -35,17 +35,17 @@
 
 - title: 'Using Codewind remotely'
   children:
-    - title: '1. Overview: Using Codewind remotely'
+    - title: 'Overview: Using Codewind remotely'
       url: remote-codewind-overview.html
-    - title: '2. Connecting your IDE to remote Codewind'
+    - title: 'Connecting your IDE to remote Codewind'
       children:
       - title: 'Connecting VS Code to remote Codewind'
         url: remotedeploy-vscode.html
       - title: 'Connecting Eclipse to remote Codewind'
         url: remotedeploy-eclipse.html
-    - title: '3. Adding an image registry in remote Codewind'
+    - title: 'Adding an image registry in remote Codewind'
       url: remote-setupregistries.html
-    - title: '4. Creating and importing projects'
+    - title: 'Creating and importing projects'
       url: remotedeploy-projects-vscode.html
 
 - title: 'Using Codewind on Eclipse Che'


### PR DESCRIPTION
Signed-off-by: MelHopper <melanieh@uk.ibm.com>

## What type of PR is this ? 

- [x ] Bug fix
- [ ] Enhancement

## What does this PR do ?
Removes numbering of topics in H nav for remote in order to prevent defect https://github.com/eclipse/codewind/issues/3092 appearing in master branch

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/3092 whilst awaiting a proper fix.
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/3092
## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
Other numbering of topics will remain in master branch, fix is being worked on this week for that single child tree issue. 