### PR TITLE
Resolve quick guide objectives appearing twice

### DIFF
--- a/docs/_guides/codewind-eclipse-quick-guide.md
+++ b/docs/_guides/codewind-eclipse-quick-guide.md
@@ -7,13 +7,9 @@ guide_description: "Take advantage of Codewind's tools to help build high qualit
 permalink: codewind-eclipse-quick-guide.html
 duration: 5 minutes
 tags: Codewind, Eclipse, microservice
-objectives: ["Install Eclipse and Codewind", "Develop a simple microservice, using Eclipse Codewind in Eclipse"]
+objectives: ["Install Eclipse and Codewind.", "Develop a simple microservice that uses Eclipse Codewind in Eclipse."]
 icon: images/learn/icon_logoEclipse.svg
 ---
-
-## Objectives
-* Install Eclipse and Codewind.
-* Develop a simple microservice that uses Eclipse Codewind in Eclipse.
 
 ## Overview
 Use Eclipse Codewind to create application projects from Application Stacks that your company builds. With Codewind, you can focus on your code and not on infrastructure and Kubernetes. Application deployments to Kubernetes occur through pipelines when developers commit their local code to the correct Git repos Kabanero is managing through webhooks.

--- a/docs/_guides/codewind-vs-code-quick-guide.md
+++ b/docs/_guides/codewind-vs-code-quick-guide.md
@@ -7,13 +7,9 @@ guide_description: "Take advantage of Codewind's tools to help build high qualit
 permalink: codewind-vscode-quick-guide.html
 duration: 5 minutes
 keywords: Codewind, VS Code, microservice
-objectives: ["Install Visual Studio Code (VS Code) and Codewind", "Develop a simple microservice, using Eclipse Codewind on VS Code"]
+objectives: ["Install Visual Studio Code (VS Code) and Codewind.", "Develop a simple microservice that uses Eclipse Codewind in VS Code."]
 icon: images/learn/icon_logoVScode.svg
 ---
-
-## Objectives
-* Install Visual Studio Code (VS Code) and Codewind.
-* Develop a simple microservice that uses Eclipse Codewind on VS Code.
 
 ## Overview
 Use Eclipse Codewind to create application projects from Application Stacks that your company builds. With Codewind, you can focus on your code and not on infrastructure and Kubernetes. Application deployments to Kubernetes occur through pipelines when developers commit their local code to the correct Git repos Kabanero is managing through webhooks.


### PR DESCRIPTION
Signed-off-by: micgibso <MICGIBSO@uk.ibm.com>

## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
In the Guides section, the objectives appear twice following merging of the https://github.com/eclipse/codewind-docs/pull/629 and https://github.com/eclipse/codewind-docs/pull/630 PRs. 

This PR resolves that. 

## Which issue(s) does this PR fix ?
No issue, see above. 

## Does this PR require a documentation change ?
Yes. 

## Any special notes for your reviewer ?
Ran it up locally and only one Objective shows for each guide. 

@j-c-berger @sishida Please review and merge. thx. 

[Update: This PR removes the 'Objectives' wording from the text in favor of having it in the metadata; it also tweaks the wording to that on PRs #629 and #630. Discussed with @jcockbain and James mentioned PR https://github.com/eclipse/codewind-docs/pull/645 which, as it's title suggests, improves the design of the Guides page by surfacing more information.]