### PR TITLE
Allow numbered dropdowns in sidebar

### DIFF
--- a/docs/_includes/docs-sidebar.html
+++ b/docs/_includes/docs-sidebar.html
@@ -7,7 +7,8 @@
         {% if levelone.children %}
 
 
-        {% assign hash = levelone.title | downcase | replace: " ", "_" %}
+        <!-- must be a valid css selector, or will break collapse function -->
+        {% assign hash = levelone.title | downcase | replace: " ", "_" | replace: ".", "" | prepend: "_" %}
 
         <a href="#{{ hash }}" id="#{{ hash }}"
             class="bg-light list-group-item list-group-item-action flex-column align-items-start" data-toggle="collapse"
@@ -18,7 +19,7 @@
 
             {% if leveltwo.children %}
 
-            {% assign hashtwo = leveltwo.title | downcase | replace: " ", "_" %}
+            {% assign hashtwo = leveltwo.title | downcase | replace: " ", "_" | replace: ".", "" | prepend: "_" %}
 
             <a href="#{{ hashtwo }}" id="#{{ hashtwo }}"
                 class="bg-light list-group-item list-group-item-action flex-column align-items-start"


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Allows dropdown items in the docs sidebar to begin with a number. 

As is, the Bootstrap collapse class isn't working when this is the case. This is because the title of a numbered dropdown is being filtered into an invalid css selector. 

More information on that here: https://stackoverflow.com/questions/54311361/bootstrap-accordion-not-working-if-id-is-number. 

Prepends an "_", and removes all "." chars, which allows both numbered and non-numbered dropdowns.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/3092

## Does this PR require a documentation change ?

No

## Any special notes for your reviewer ?

Can be tested by changing the value of the dropdown titles in `datastoc.yml` 
to begin with "1." as an example.
 