### PR TITLE
Adding numbering to Using Codewind Remotely getting started topics to…

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -35,17 +35,17 @@
 
 - title: 'Using Codewind remotely'
   children:
-    - title: 'Overview: Using Codewind remotely'
+    - title: '1. Overview: Using Codewind remotely'
       url: remote-codewind-overview.html
-    - title: 'Connecting your IDE to remote Codewind'
+    - title: '2. Connecting your IDE to remote Codewind'
       children:
       - title: 'Connecting VS Code to remote Codewind'
         url: remotedeploy-vscode.html
       - title: 'Connecting Eclipse to remote Codewind'
         url: remotedeploy-eclipse.html
-    - title: 'Adding an image registry in remote Codewind'
+    - title: '3. Adding an image registry in remote Codewind'
       url: remote-setupregistries.html
-    - title: 'Creating and importing projects'
+    - title: '4. Creating and importing projects'
       children:
       - title: 'VS Code' 
         url: remotedeploy-projects-vscode.html


### PR DESCRIPTION
… improve the user workflow

Signed-off-by: MelHopper <melanieh@uk.ibm.com>

## What type of PR is this ? 

- [x ] Bug fix
- [ ] Enhancement

## What does this PR do ?
Adds numbering to topics in ToC for Using Codewind Remotely in the same way as for other Getting Started user workflows.

## Which issue(s) does this PR fix ?
Adding numbering to topics in LH nav has broken subtree function
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

https://github.com/eclipse/codewind/issues/3092

## Does this PR require a documentation change ?
n/a - done via this PR

## Any special notes for your reviewer ?
I've verified the subtrees do now open when the numbering is applied to the Using Codewind Remotely topics.