### PR TITLE
Remove sticky top from sidebar

### DIFF
--- a/docs/_includes/docs-sidebar.html
+++ b/docs/_includes/docs-sidebar.html
@@ -1,6 +1,6 @@
 <div id="sidebar-container" class="bg-light" role="navigation" aria-label="sidebar">
     <!-- Bootstrap List Group -->
-    <ul class="list-group sticky-top bg-light cw-sticky-offset">
+    <ul class="list-group bg-light">
 
         {% for levelone in site.data.docstoc %}
 

--- a/docs/_layouts/news.html
+++ b/docs/_layouts/news.html
@@ -2,22 +2,22 @@
 <!-- Bootstrap row -->
 <div class="row" id="body-row">
     <!-- Sidebar -->
-    
-    
+
+
 
     <div id="sidebar-container" class="bg-light"  role="navigation" aria-label="sidebar">
         <!-- Bootstrap List Group -->
-        <ul class="list-group sticky-top bg-light cw-sticky-offset">
-            
+        <ul class="list-group bg-light">
+
             <!-- Hard coded TOC -->
             <!-- Start single page getting started -->
-            
+
             {% for entry in site.data.newstoc %}
 		      {% if entry.children %}
-			
+
 			  {% else %}
-			  
-				<a href="{{ entry.url }}" 
+
+				<a href="{{ entry.url }}"
 				    {% assign cls = "bg-light list-group-item list-group-item-action" %}
 				    {% assign url = '/' | append: entry.url | remove: ".html" %}
 					{% if url == page.url %}
@@ -26,13 +26,13 @@
 					class="{{cls}}">
 					{{ entry.title}}
 	            </a>
-	            
+
 			  {% endif %}
 			{% endfor %}
-			
+
 			<!-- END hard coded TOC -->
 
-            
+
         </ul>
         <!-- List Group END-->
     </div>
@@ -43,9 +43,9 @@
     		    <div class="cw-docs-spacer"></div>
         		<div role="main">{{ content }}</div>
         </div>
-        
+
     </div>
-    
+
 </div>
 {% include footer.html %}
 <!-- Main Col END -->


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Fixes the main part of https://github.com/eclipse/codewind/issues/2049, which is that a user has to scroll to the bottom of a long docs page to view the bottom of the sidebar. 

This was being caused by the bootstrap class `sticky-top`. 

I've tested thoroughly on both desktop and mobile view and I can't see any problems when the class is removed.

To test: 

- Go to a relatively long docs page (e.g. https://www.eclipse.org/codewind/remotedeploy-vscode.html)

- Open up multiple expanders on the side bar to make it larger than the page view-height

- Scroll down, on currently the sidebar sticks to the top until you reach the foot of the page... with this change the sidebar is scrolled past

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2049

Note: This issue does mention independent scrolling of sidebar and main content. 

Given how the sidebar is coded and styled, this would require a much more significant change. 

In my opinion, this resolves the main UX bug without drastic change.
