### PR TITLE
Fix expander overlapping text on docs sidebar

### DIFF
--- a/docs/_includes/docs-sidebar.html
+++ b/docs/_includes/docs-sidebar.html
@@ -10,9 +10,14 @@
         <!-- must be a valid css selector, or will break collapse function -->
         {% assign hash = levelone.title | downcase | replace: " ", "_" | replace: ".", "" | prepend: "_" %}
 
-        <a href="#{{ hash }}" id="#{{ hash }}"
-            class="bg-light list-group-item list-group-item-action flex-column align-items-start" data-toggle="collapse"
-            aria-expanded="false">{{ levelone.title }}<span class="submenu-icon"></span></a>
+        <a href="#{{ hash }}" id="#{{ hash }}" class="bg-light list-group-item list-group-item-action"
+            data-toggle="collapse" aria-expanded="false">
+            <div class="d-flex align-items-center">
+                {{ levelone.title }}
+                <span class="submenu-icon"></span>
+            </div>
+        </a>
+
         <div class="cw-sidebar-div cw-sidebar-submenu collapse" id="{{ hash }}">
 
             {% for leveltwo in levelone.children %}
@@ -21,10 +26,13 @@
 
             {% assign hashtwo = leveltwo.title | downcase | replace: " ", "_" | replace: ".", "" | prepend: "_" %}
 
-            <a href="#{{ hashtwo }}" id="#{{ hashtwo }}"
-                class="bg-light list-group-item list-group-item-action flex-column align-items-start"
-                data-toggle="collapse" data-parent="#{{ hash }}" aria-expanded="false">{{ leveltwo.title }}<span
-                    class="submenu-icon"></span></a>
+            <a href="#{{ hashtwo }}" id="#{{ hashtwo }}" class="bg-light list-group-item list-group-item-action"
+                data-toggle="collapse" data-parent="#{{ hash }}" aria-expanded="false">
+                <div class="d-flex align-items-center">
+                    {{ leveltwo.title }}
+                    <span class="submenu-icon"></span>
+                </div>
+            </a>
 
             <div class="cw-sidebar-div cw-sidebar-submenu-submenu collapse" id="{{ hashtwo }}">
 

--- a/docs/css/docs.css
+++ b/docs/css/docs.css
@@ -68,6 +68,7 @@ code {
 
 #sidebar-container .list-group .cw-sidebar-submenu a {
     padding-left: 30px;
+    padding-right: 30px;
 }
 
 #sidebar-container .list-group .cw-sidebar-submenu .cw-sidebar-submenu-submenu a {


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Fixes bug whereby a sidebar expander title of a certain length was causing the expander icon to overlap the text.

Does so by increasing right padding on the list text to match the left, causing the list item to wrap before occupying the same space as the icon.

Also ensures text and icon are aligned horizontally by wrapping them in a div, like the examples in https://getbootstrap.com/docs/4.5/components/list-group/.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/3129
