### PR TITLE
Add IntelliJ image to homepage hero

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -225,12 +225,23 @@ code {
     width: 100%
 }
 
+#hero-main-hero-intellij {
+    position: absolute;
+    top: 41px;
+    left: 561px;
+}
+
 #hero-main-hero-vscode img {
     max-width: 545px;
     -moz-box-shadow: -5px 5px 15px 0px #3a3a3a;
     -webkit-box-shadow: -5px 5px 15px 0px #3a3a3a;
     box-shadow: -5px 5px 15px 0px #3a3a3a;
     width: 100%;
+}
+
+#hero-main-hero-intellij img {
+    max-width: 378px;
+    width: 100%
 }
 
 #hero-main-headline {
@@ -240,7 +251,7 @@ code {
 #hero-main-hero {
     left: 50px;
     position: relative;
-    max-width: 784px;
+    max-width: 950px;
     width: 100%;
     top: 129px;
     font-size: 12px;
@@ -332,7 +343,7 @@ code {
 }
 
 .cw-logo-separator {
-    
+
     height: 60px;
 }
 
@@ -502,7 +513,7 @@ code {
 	position: relative;
 }
 .cw-footer-eclipse-img img {
-	
+
 }
 /* end footer */
 
@@ -541,15 +552,25 @@ code {
     }
 
     #hero-main-hero-eclipse {
+        top: 50px;
         left: 100px;
     }
 
     #hero-main-hero-che {
-        top: 150px;
+        top: 100px;
         left: 200px;
     }
 
+    #hero-main-hero-intellij {
+        top: 150px;
+        left: 300px;
+    }
+
     #hero-main-hero-eclipse>div {
+        text-align: right;
+    }
+
+    #hero-main-hero-intellij>div {
         text-align: right;
     }
 
@@ -563,7 +584,7 @@ code {
         margin-right: calc(50% - 500px);
     }
     #hero-turbine-svg {
-        
+
         margin-left: calc(50% - 550px);
     }
 
@@ -576,23 +597,23 @@ code {
 	.cw-header-link {
         padding-left: 18px;
 	}
-	
+
 	.cw-header-link-news {
 	    padding-right: 18px;
 	}
-    
+
     .cw-header-link-blog {
 	    padding-right: 18px;
     }
-    
+
     .cw-header-link-guides {
 	    padding-right: 18px;
 	}
-    
+
 	.cw-header-link-docs {
 		padding-right: 26px;
 	}
-	
+
     /* hero section */
     #hero-main-text {
         max-width: 400px;
@@ -603,12 +624,18 @@ code {
     }
 
     #hero-main-hero-eclipse {
-        left: 80px;
+        top: 60px;
+        left: 60px;
     }
 
     #hero-main-hero-che {
-        top: 150px;
-        left: 160px;
+        top: 120px;
+        left: 120px;
+    }
+
+    #hero-main-hero-intellij {
+        top: 180px;
+        left: 180px;
     }
 
     #hero-main-hero {
@@ -622,7 +649,7 @@ code {
     }
 
     #hero-turbine-svg {
-        
+
         margin-left: calc(50% - 480px);
     }
 
@@ -638,7 +665,7 @@ code {
     }
 
     #hero-main img {
-        width: calc(100% - 160px);
+        width: calc(100% - 180px);
     }
 
     #hero-main-hero-eclipse {
@@ -648,20 +675,36 @@ code {
 
     #hero-main-hero-eclipse img {
         max-width: unset;
-        width: calc(100% - 80px);
+        width: calc(100% - 130px);
     }
 
     #hero-main-hero-che {
-        top: 180px;
         left: 160px;
+        top: 180px;
     }
 
     #hero-main-hero-che img {
+        max-width: unset;
+        width: calc(100% - 80px);
+    }
+
+
+    #hero-main-hero-intellij {
+        left: 240px;
+        top: 270px;
+    }
+
+
+    #hero-main-hero-intellij img {
         max-width: unset;
         width: 100%;
     }
 
     #hero-main-hero-eclipse>div {
+        text-align: left;
+    }
+
+    #hero-main-hero-intellij>div {
         text-align: left;
     }
 
@@ -682,7 +725,7 @@ code {
     }
 
     #hero-turbine-svg {
-        
+
         margin-left: calc(50% - 100px);
     }
     /* end hero section */
@@ -704,7 +747,7 @@ code {
 
     }
 
-    /* nav bar*/ 
+    /* nav bar*/
     #github-stars-button {
         display: none;
     }
@@ -737,7 +780,7 @@ code {
 	.cw-logo-mm {
     		max-height: 45px;
 	}
-    
+
     /* end footer */
 }
 
@@ -751,21 +794,21 @@ code {
     }
 
     /* end hero */
-    
+
     /* side bar */
-    
-    
-    
+
+
+
     /* end side bar */
     /* footer */
     .cw-footer-col {
     		padding: 10px;
     }
-    
+
     .cw-footer-border-right {
 	    display: none;
 	}
-	
+
 	#footer-div-mobile {
 	background: #0073ba;
 	padding-bottom: 30px;
@@ -787,7 +830,7 @@ code {
     .cw-footer-eclipse-img img {
     		padding-bottom: 0px;
     }
-    
+
     .cw-logo {
     		max-height: 30px;
     		margin-top: 30px;
@@ -799,9 +842,9 @@ code {
 	.cw-logo-eclipse-mobile {
 		margin-top: 30px;
 	}
-	
-	
-	
+
+
+
     /* end footer */
     #value-props-div {
     		padding-top: 40px;
@@ -809,33 +852,33 @@ code {
     		padding-left: 0px;
     		padding-right: 0px;
     }
-    
+
     #key-features-div {
 	    padding-top: 20px;
 	    padding-bottom: 40px;
 	    padding-left: 0;
 	    padding-right: 0;
 	}
-	
+
 	.cw-value-props-col-header {
-	
+
     		padding-left: 0;
     		padding-right: 0;
     	}
-    	
+
     	.cw-value-props-div-text {
-	
+
     		padding-left: 0;
     		padding-right: 0;
     	}
-    	
+
     	.cw-youtube-view-font {
 	    font-size: unset;
 	}
 	.cw-smile-icon {
 		width: 22px;
 	}
-	
+
 	#footer-div-mobile {
 		padding-top: 20px;
 	}
@@ -850,28 +893,38 @@ code {
     }
 
     #hero-main img {
-        width: calc(100% - 60px);
+        width: calc(100% - 80px);
     }
 
     #hero-main-hero {
         top: 50px;
     }
     #hero-main-hero-eclipse {
-        left: 80px;
-        top: 100px;
+        left: 60px;
+        top: 70px;
     }
 
     #hero-main-hero-eclipse img {
         max-width: unset;
-        width: calc(100% - 30px);
+        width: calc(100% - 60px);
     }
 
     #hero-main-hero-che {
-        top: 200px;
-        left: 160px;
+        left: 120px;
+        top: 140px;
     }
 
     #hero-main-hero-che img {
+        max-width: unset;
+        width: calc(100% - 40px);
+    }
+
+    #hero-main-hero-intellij {
+        left: 180px;
+        top: 210px;
+    }
+
+    #hero-main-hero-intellij img {
         max-width: unset;
         width: 100%;
     }
@@ -886,8 +939,6 @@ code {
 /* Small devices (portrait tablets and large phones, 500px and below) */
 @media only screen and (max-width: 500px) {
 
-    
-
     #hero-main-hero {
         top: 10px;
     }
@@ -896,15 +947,15 @@ code {
 /* Small devices (portrait tablets and large phones, 440px and below) */
 @media only screen and (max-width: 440px) {
 
-    
+
 
     #hero-main-hero {
         top: 10px;
     }
-    
+
     #hero-main-hero-eclipse {
-       
-        top: 70px;
+
+        top: 40px;
     }
 
     #hero-main-hero-eclipse img {
@@ -912,7 +963,21 @@ code {
         width: calc(100% - 30px);
     }
 
+    #hero-main-hero-che img {
+        max-width: unset;
+        width: calc(100% - 15px);
+    }
+
+    #hero-main-hero-intellij img {
+        max-width: unset;
+        width: 100%;
+    }
+
     #hero-main-hero-che {
+        top: 80px;
+    }
+
+    #hero-main-hero-intellij{
         top: 120px;
     }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,16 +33,19 @@ home: true
         <div id="hero-main-hero">
             <div id="hero-main-hero-vscode">
                 <div>VS Code</div>
-                <div style="z-index:1"><img alt="vscode ide" title="vscode ide"
-                        src="images/index/hero-vscode-noshadow.png"></div>
+                <div><img alt="vscode ide" title="vscode ide" src="images/index/hero-vscode-noshadow.png"></div>
             </div>
             <div id="hero-main-hero-eclipse">
                 <div>Eclipse</div>
                 <div><img alt="eclipse ide" title="eclipse ide" src="images/index/hero-eclipse-noshadow.png"></div>
             </div>
             <div id="hero-main-hero-che">
-                <div class="text-right">Eclipse Che</div>
+                <div>Eclipse Che</div>
                 <div><img alt="che ide" title="che ide" src="images/index/hero-che-noshadow.png"></div>
+            </div>
+            <div id="hero-main-hero-intellij">
+                <div>IntelliJ</div>
+                <div><img alt="intellij ide" title="intellij ide" src="images/index/hero-intellij-noshadow.png"></div>
             </div>
         </div>
     </div>
@@ -64,7 +67,7 @@ home: true
             development and fast feedback directly in your IDE.
         </div>
         <div class="cw-value-props-col-img-holder">
-            <img alt="container image"  title="container image" src="images/index/container-icon.svg" class="cw-logo" />
+            <img alt="container image" title="container image" src="images/index/container-icon.svg" class="cw-logo" />
         </div>
     </div>
     <div class="col-lg-4 col-md-6 cw-value-props-col cw-getting-started-col text-center">
@@ -75,7 +78,7 @@ home: true
             Code in the tools you use today, for the runtimes and languages you use today.
         </div>
         <div class="cw-value-props-col-img-holder">
-            <img alt="knowledge image"  title="knowledge image" src="images/index/knowledge-icon.svg" class="cw-logo" />
+            <img alt="knowledge image" title="knowledge image" src="images/index/knowledge-icon.svg" class="cw-logo" />
         </div>
     </div>
     <div class="col-lg-4 col-md-6 cw-value-props-col text-center">
@@ -86,7 +89,7 @@ home: true
             you go.
         </div>
         <div class="cw-value-props-col-img-holder">
-            <img alt="kubernetes image"  title="kubernetes image" src="images/index/kubernetes.svg" class="cw-logo" />
+            <img alt="kubernetes image" title="kubernetes image" src="images/index/kubernetes.svg" class="cw-logo" />
         </div>
     </div>
 </div>
@@ -95,7 +98,7 @@ home: true
 <!-- value props div e end -->
 
 <!-- key features row -->
-<div class="row" id="key-features-div" >
+<div class="row" id="key-features-div">
     <div class="col-md-12 cw-key-features-header text-center">Key features</div>
     <div class="col-lg-3 col-md-6 cw-getting-started-col text-center">
 
@@ -105,7 +108,7 @@ home: true
             updates in the running container.
         </div>
         <div>
-            <img alt="inner loop image"  title="inner loop image" src="images/index/inner-loop.svg" class="cw-logo" />
+            <img alt="inner loop image" title="inner loop image" src="images/index/inner-loop.svg" class="cw-logo" />
         </div>
     </div>
     <div class="col-lg-3 col-md-6 cw-getting-started-col text-center">
@@ -118,7 +121,7 @@ home: true
             tools in local or hosted IDE, and run in local containers or deployed directly on Kubernetes.
         </div>
         <div>
-            <img alt="container image"  title="container image" src="images/index/container2-icon.svg" class="cw-logo" />
+            <img alt="container image" title="container image" src="images/index/container2-icon.svg" class="cw-logo" />
         </div>
     </div>
     <div class="col-lg-3 col-md-6 cw-getting-started-col text-center">
@@ -130,7 +133,7 @@ home: true
             integration with Eclipse, Eclipse Che, IntelliJ, and VS Code.
         </div>
         <div>
-            <img alt="ide icon"  title="ide icon" src="images/index/ide-icon.svg" class="cw-logo" />
+            <img alt="ide icon" title="ide icon" src="images/index/ide-icon.svg" class="cw-logo" />
         </div>
     </div>
     <div class="col-lg-3 col-md-6 text-center">
@@ -145,7 +148,7 @@ home: true
             graphs.
         </div>
         <div>
-            <img alt="monitoring icon"  title="monitoring icon" src="images/index/monitoring-icon.svg" class="cw-logo" />
+            <img alt="monitoring icon" title="monitoring icon" src="images/index/monitoring-icon.svg" class="cw-logo" />
         </div>
     </div>
 
@@ -155,22 +158,28 @@ home: true
 <!-- key features row END -->
 
 <div class="row">
-	<div class="col-xl-6 col-offset-xl-2 col-md-12 col-sm-12">
-		<div class="p-md-5">
-		<span class="cw-youtube-view-font">View the demo</span>
-			<div class="embed-responsive embed-responsive-16by9">
+    <div class="col-xl-6 col-offset-xl-2 col-md-12 col-sm-12">
+        <div class="p-md-5">
+            <span class="cw-youtube-view-font">View the demo</span>
+            <div class="embed-responsive embed-responsive-16by9">
 
-				<iframe width="1280" height="720" title="Codewind youtube video" src="https://www.youtube.com/embed/mjADP2_4FBg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-			</div>
-		</div>
-	</div>
-	<div class="col-xl-6 col-md-12 col-sm-12 cw-v-middle">
-		<div class="p-5 cw-youtube-desc">
-			<span class="cw-youtube-view-font cw-youtube-italic">Containerize existing applications and create new applications in several languages.</span>
-<br/><br/>
-			<span class="cw-youtube-view-font cw-youtube-thin">Leave behind, </span><span class="cw-youtube-view-font cw-youtube-italic cw-youtube-bold">“But it worked on my machine!” </span><span class="cw-youtube-view-font cw-youtube-thin"></span>
-			&nbsp;&nbsp;
-			<img src="images/smile.svg" alt="smile face" class="cw-smile-icon">
-		</div>
-	</div>
+                <iframe width="1280" height="720" title="Codewind youtube video"
+                    src="https://www.youtube.com/embed/mjADP2_4FBg" frameborder="0"
+                    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+            </div>
+        </div>
+    </div>
+    <div class="col-xl-6 col-md-12 col-sm-12 cw-v-middle">
+        <div class="p-5 cw-youtube-desc">
+            <span class="cw-youtube-view-font cw-youtube-italic">Containerize existing applications and create new
+                applications in several languages.</span>
+            <br /><br />
+            <span class="cw-youtube-view-font cw-youtube-thin">Leave behind, </span><span
+                class="cw-youtube-view-font cw-youtube-italic cw-youtube-bold">“But it worked on my machine!”
+            </span><span class="cw-youtube-view-font cw-youtube-thin"></span>
+            &nbsp;&nbsp;
+            <img src="images/smile.svg" alt="smile face" class="cw-smile-icon">
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?

Add IntelliJ screenshot to hero on the main page. 

![image](https://user-images.githubusercontent.com/31372187/84672612-a88f4f80-af20-11ea-9105-bcab26cdc3c5.png)

Styling added to resize the screenshot at all breakpoints, for some adjustments are made to the other 3 images to fit in the extra image.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2913

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?

No

## Any special notes for your reviewer ?

Changes deployed to https://jcockbain.github.io/codewind-docs/ for testing. Resizing the page is the most important to test.