### PR TITLE
Improve resizing of learn page, for widths 750-1000px

### DIFF
--- a/docs/css/learn.css
+++ b/docs/css/learn.css
@@ -45,3 +45,16 @@
   right: 0;
 }
 
+.row.equal-height {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.row.equal-height>[class*='col'] {
+  display: flex;
+  flex-direction: column;
+}
+
+.card {
+  flex: 1;
+}

--- a/docs/learn.html
+++ b/docs/learn.html
@@ -15,68 +15,104 @@ redirect_from:
       application and runtime environment standards, by extending their
       Integrated Development Environment (IDE).
       <a href="overview.html">Learn more</a> or
-      <a href="want-to-get-a-microservice-up-and-running-super-quickly-try-codewind.html">see it in action</a>.
+      <a
+        href="want-to-get-a-microservice-up-and-running-super-quickly-try-codewind.html"
+        >see it in action</a
+      >.
     </div>
-    <div class="card-deck w-100">
-      <div class="card learn-card">
-        <div class="card-header">
-          <div class="d-flex align-items-center justify-content-between">
-            <h5 class="my-2">
-              Desktop and remote
-            </h5>
-            <div>
-              <img alt="Cloud icon" title="cloud icon" src="images/learn/icon_cloud.svg" />
-              <img alt="Desktop icon" title="desktop icon" src="images/learn/icon_desktop.svg" />
+    <div class="row equal-height w-100">
+      <div class="col-12 col-lg-6 py-3 py-lg-0">
+        <div class="card learn-card">
+          <div class="card-header">
+            <div class="d-flex align-items-center justify-content-between">
+              <h5 class="my-2">
+                Desktop and remote
+              </h5>
+              <div>
+                <img
+                  alt="Cloud icon"
+                  title="cloud icon"
+                  src="images/learn/icon_cloud.svg"
+                />
+                <img
+                  alt="Desktop icon"
+                  title="desktop icon"
+                  src="images/learn/icon_desktop.svg"
+                />
+              </div>
+            </div>
+          </div>
+          <div class="card-body d-flex flex-column">
+            <p>
+              Download to develop, build and run on your desktop, or to develop
+              on your desktop but build and run on the cloud. Follow
+              step-by-step instructions for
+              <a href="vsc-getting-started.html">VS Code</a>,
+              <a href="eclipse-getting-started.html">Eclipse</a>, or
+              <a href="intellij-getting-started.html">IntelliJ</a>.
+            </p>
+            <div
+              class="col d-flex justify-content-start flex-column flex-xl-row"
+            >
+              <a
+                href="https://marketplace.visualstudio.com/items?itemName=IBM.codewind"
+                class="mt-auto btn btn-primary m-2"
+                role="button"
+              >
+                VS Code
+                <i class="fa fa-download button-icon"></i>
+              </a>
+              <a
+                href="https://marketplace.eclipse.org/content/codewind"
+                class="mt-auto btn btn-primary m-2"
+                role="button"
+              >
+                Eclipse
+                <i class="fa fa-download button-icon"></i>
+              </a>
+              <a
+                href="https://plugins.jetbrains.com/plugin/13839-codewind"
+                class="mt-auto btn btn-primary m-2"
+                role="button"
+              >
+                IntelliJ
+                <i class="fa fa-download button-icon"></i>
+              </a>
             </div>
           </div>
         </div>
-        <div class="card-body d-flex flex-column">
-          <p>
-            Download to develop, build and run on your desktop, or to develop on
-            your desktop but build and run on the cloud. Follow step-by-step
-            instructions for <a href="vsc-getting-started.html">VS Code</a>,
-            <a href="eclipse-getting-started.html">Eclipse</a>, or
-            <a href="intellij-getting-started.html">IntelliJ</a>.
-          </p>
-          <div class="col d-flex justify-content-start flex-column flex-xl-row">
-            <a href="https://marketplace.visualstudio.com/items?itemName=IBM.codewind"
-              class="mt-auto btn btn-primary m-2" role="button">
-              VS Code
-              <i class="fa fa-download button-icon"></i>
-            </a>
-            <a href="https://marketplace.eclipse.org/content/codewind" class="mt-auto btn btn-primary m-2"
-              role="button">
-              Eclipse
-              <i class="fa fa-download button-icon"></i>
-            </a>
-            <a href="https://plugins.jetbrains.com/plugin/13839-codewind" class="mt-auto btn btn-primary m-2"
-              role="button">
-              IntelliJ
-              <i class="fa fa-download button-icon"></i>
-            </a>
-          </div>
-        </div>
       </div>
-      <div class="card learn-card">
-        <div class="card-header">
-          <div class="d-flex align-items-center justify-content-between">
-            <h5 class="my-2">
-              Browser based
-            </h5>
-            <img alt="Cloud icon" title="cloud icon" src="images/learn/icon_cloud.svg" />
+      <div class="col-12 col-lg-6 py-3 py-lg-0">
+        <div class="card learn-card">
+          <div class="card-header">
+            <div class="d-flex align-items-center justify-content-between">
+              <h5 class="my-2">
+                Browser based
+              </h5>
+              <img
+                alt="Cloud icon"
+                title="cloud icon"
+                src="images/learn/icon_cloud.svg"
+              />
+            </div>
           </div>
-        </div>
-        <div class="card-body d-flex flex-column justify-content-between">
-          <p>
-            Download to develop, build and run entirely on the cloud,
-            <a href="che-installinfo.html ">step-by-step instructions</a>.
-          </p>
-          <div class="col d-flex justify-content-start flex-column flex-xl-row">
-            <a href="https://github.com/eclipse/codewind-che-plugin/blob/0.13.0/setup/install_che/che-operator/codewind-checluster.yaml"
-              class="mt-auto btn btn-primary m-2" role="button">
-              Eclipse Che
-              <i class="fa fa-download button-icon"></i>
-            </a>
+          <div class="card-body d-flex flex-column justify-content-between">
+            <p>
+              Download to develop, build and run entirely on the cloud,
+              <a href="che-installinfo.html ">step-by-step instructions</a>.
+            </p>
+            <div
+              class="col d-flex justify-content-start flex-column flex-xl-row"
+            >
+              <a
+                href="https://github.com/eclipse/codewind-che-plugin/blob/0.13.0/setup/install_che/che-operator/codewind-checluster.yaml"
+                class="mt-auto btn btn-primary m-2"
+                role="button"
+              >
+                Eclipse Che
+                <i class="fa fa-download button-icon"></i>
+              </a>
+            </div>
           </div>
         </div>
       </div>
@@ -85,51 +121,72 @@ redirect_from:
 
   <div class="row p-5">
     <h3 class="mt-0 mb-4">Get started by job role</h3>
-    <div class="card-deck w-100">
-      <div class="card learn-card">
-        <div class="card-body">
-          <div class="d-flex align-items-center mb-2">
-            <img alt="Developer icon" title="developer icon" src="images/learn/icon_roleDeveloper.svg" />
-            <h5 class="my-2">
-              Developer
-            </h5>
+    <div class="row equal-height">
+      <div class="col-12 col-lg-4 py-3 py-lg-0">
+        <div class="card learn-card">
+          <div class="card-body">
+            <div class="d-flex align-items-center mb-2">
+              <img
+                alt="Developer icon"
+                title="developer icon"
+                src="images/learn/icon_roleDeveloper.svg"
+              />
+              <h5 class="my-2">
+                Developer
+              </h5>
+            </div>
+            <p>
+              If you are a developer, learn how to set up and start using
+              Codewind on <a href="vsc-getting-started.html">VS Code</a>,
+              <a href="eclipse-getting-started.html">Eclipse</a>,
+              <a href="intellij-getting-started.html">IntelliJ</a>, or
+              <a href="che-installinfo.html">Eclipse Che</a>.
+            </p>
           </div>
-          <p>
-            If you are a developer, learn how to set up and start using Codewind
-            on <a href="vsc-getting-started.html">VS Code</a>,
-            <a href="eclipse-getting-started.html">Eclipse</a>,
-            <a href="intellij-getting-started.html">IntelliJ</a>, or
-            <a href="che-installinfo.html">Eclipse Che</a>.
-          </p>
         </div>
       </div>
-      <div class="card learn-card">
-        <div class="card-body">
-          <div class="d-flex align-items-center mb-2">
-            <img alt="SysAdmin icon" title="sysAdmin icon" src="images/learn/icon_roleSysAdmin.svg" />
-            <h5 class="my-2">
-              SysAdmin or Devops
-            </h5>
+      <div class="col-12 col-lg-4 py-3 py-lg-0">
+        <div class="card learn-card">
+          <div class="card-body">
+            <div class="d-flex align-items-center mb-2">
+              <img
+                alt="SysAdmin icon"
+                title="sysAdmin icon"
+                src="images/learn/icon_roleSysAdmin.svg"
+              />
+              <h5 class="my-2">
+                SysAdmin or Devops
+              </h5>
+            </div>
+            <p>
+              If you are a sysadmin or DevOps engineer, learn how to
+              <a href="remote-deploying-codewind.html"
+                >deploy Codewind remotely</a
+              >.
+            </p>
           </div>
-          <p>
-            If you are a sysadmin or DevOps engineer, learn how to
-            <a href="remote-deploying-codewind.html">deploy Codewind remotely</a>.
-          </p>
         </div>
       </div>
-      <div class="card learn-card">
-        <div class="card-body">
-          <div class="d-flex align-items-center mb-2">
-            <img alt="Architect icon" title="architect icon" src="images/learn/icon_roleArchitect.svg" />
-            <h5 class="my-2">
-              Solution Architect
-            </h5>
+      <div class="col-12 col-lg-4 py-3 py-lg-0">
+        <div class="card learn-card">
+          <div class="card-body">
+            <div class="d-flex align-items-center mb-2">
+              <img
+                alt="Architect icon"
+                title="architect icon"
+                src="images/learn/icon_roleArchitect.svg"
+              />
+              <h5 class="my-2">
+                Solution Architect
+              </h5>
+            </div>
+            <p>
+              If you are responsible for defining standards for the application
+              and runtime environments, such as framework and software levels
+              see,
+              <a href="workingwithtemplates.html">Working with templates</a>.
+            </p>
           </div>
-          <p>
-            If you are responsible for defining standards for the application
-            and runtime environments, such as framework and software levels see,
-            <a href="workingwithtemplates.html">Working with templates</a>.
-          </p>
         </div>
       </div>
     </div>
@@ -139,25 +196,32 @@ redirect_from:
     <a href="guides.html">
       <h3 class="mt-0 mb-4">Quick guides</h3>
     </a>
-    <div class="card-deck w-100">
+    <div class="row equal-height w-100">
       {% for post in site.guides limit:3 %}
-      <div class="card learn-card">
-        <div class="card-body">
-          <div class="d-flex align-items-center">
-            <h5 class="my-2">
-              <a href="{{post.permalink}}">
-                {{ post.title }}
-              </a>
-            </h5>
-            <img alt="Guide icon" class="pl-2" title="guide icon" src="{{ post.icon }}" />
+      <div class="col-12 col-lg-4 py-3 py-lg-0">
+        <div class="card learn-card">
+          <div class="card-body">
+            <div class="d-flex align-items-center">
+              <h5 class="my-2">
+                <a href="{{post.permalink}}">
+                  {{ post.title }}
+                </a>
+              </h5>
+              <img
+                alt="Guide icon"
+                class="pl-2"
+                title="guide icon"
+                src="{{ post.icon }}"
+              />
+            </div>
+            <ul>
+              {% for obj in post.objectives %}
+              <li>
+                {{ obj }}
+              </li>
+              {% endfor %}
+            </ul>
           </div>
-          <ul>
-            {% for obj in post.objectives %}
-            <li>
-              {{ obj }}
-            </li>
-            {% endfor %}
-          </ul>
         </div>
       </div>
       {% endfor %}
@@ -166,8 +230,8 @@ redirect_from:
 
   <div class="row learn-row p-5">
     <div class="row w-100">
-      {% assign blog = site.blog | where: "title", "Sneak Peek: Remote Development with Codewind" | first %}
-      {% assign video = site.data.videos | first %}
+      {% assign blog = site.blog | where: "title", "Sneak Peek: Remote Development with Codewind" | first %} {% assign video = site.data.videos |
+      first %}
       <div class="col-lg-6">
         <a href="blog.html">
           <h3 class="mt-0 mb-4">
@@ -176,7 +240,12 @@ redirect_from:
         </a>
         <div class="card learn-media-card">
           <div class="embed-responsive embed-responsive-16by9">
-            <img class="blog-image" alt="Blog image" title="blog-image" src="{{ blog.title_img }}" />
+            <img
+              class="blog-image"
+              alt="Blog image"
+              title="blog-image"
+              src="{{ blog.title_img }}"
+            />
           </div>
           <div class="card-body">
             <p class="card-text text-right">
@@ -208,8 +277,13 @@ redirect_from:
         </a>
         <div class="card learn-media-card">
           <div class="embed-responsive embed-responsive-16by9">
-            <iframe title="Codewind youtube video" src="{{ video.embed_link }}" class="embed-responsive-item"
-              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <iframe
+              title="Codewind youtube video"
+              src="{{ video.embed_link }}"
+              class="embed-responsive-item"
+              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            ></iframe>
           </div>
           <div style class="card-body">
             <p class="card-text text-right">


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Updates `/learn` for a better UX at page widths between 750px-1000px.

As described in the issue, bootstrap `card-deck`, which was used to give equal height cards, caused the cards to move to a vertical stack at too low a breakpoint. 

This changes the page to use a custom `equal-height` css class, inspired by https://github.com/twbs/bootstrap/issues/20321#issuecomment-309210866, for the equal height cards.

This allows us to manually control the breakpoint at which page-width columns are used.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/3145

## Any special notes for your reviewer ?

Changes deployed to https://jcockbain.github.io/codewind-docs/learn.html, compare to https://www.eclipse.org/codewind/learn.html between page-widths of 750-1000px (or on tablet sized device) for diff.
