### PR TITLE
Remove numbering; add "optional" as clarification

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -59,7 +59,7 @@
     url: che-installinfo.html
   - title: '2. Adding an image registry in Codewind on Eclipse Che'
     url: che-setupregistries.html
-  - title: '2a. Adding the OpenShift internal registry with Codewind'
+  - title: 'Optional: Adding the OpenShift internal registry with Codewind'
     url: openshiftregistry.html
   - title: '3. Creating a Codewind workspace in Eclipse Che'
     url: che-createcodewindworkspace.html


### PR DESCRIPTION
Signed-off-by: Sarah Ishida <sishida@us.ibm.com>

PR for issue https://github.com/eclipse/codewind/issues/3146.

I realize that we want "2. Adding an image registry in Codewind on Eclipse Che" to be the parent topic of "2a. Adding the OpenShift internal registry with Codewind." However, this currently isn't possible. A parent title cannot link to its own page and have a child topic at the same time. (I think this has been a limitation of the website from the beginning.)

If I try to make "2. Adding an image registry in Codewind on Eclipse Che" the parent, we can no longer click it and go to the page. Instead, it only opens the twistie to reveal "2a. Adding the OpenShift internal registry with Codewind," which we then can click to go to its page.

This PR proposes a compromise.