### PR TITLE
Fix hidden title on learn page for widths 750-1000px

### DIFF
--- a/docs/css/docs.css
+++ b/docs/css/docs.css
@@ -251,9 +251,6 @@ code {
 	#sidebar-container {
         padding-top: 101px;
     }
-    #content-container > div {
-        padding-top: 0px;
-    }
 }
 
 .callout {
@@ -290,7 +287,9 @@ code {
     #content-container {
         width: 100vw;
     }
-
+    #content-container > div {
+        padding-top: 0px;
+    }
     #sidebar-container {
         width: 100vw;
         	min-height: 0;


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Moves the removal of the docs content container top-padding to a lower breakpoint, matching the Table Of Contents being moved to the top of the page.

This fixes the bug where the title of the learn page is hidden for widths between 750-1000px. 

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/3151
