### PR TITLE
Crop blog and guide images on mobile

### DIFF
--- a/docs/css/blog.css
+++ b/docs/css/blog.css
@@ -39,6 +39,7 @@
 
 #post-content img {
     display: block;
+    max-width: 100%;
     margin-left: auto;
     margin-right: auto;
     padding: 1px 1px 1px 1px;


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Sets a max-width of images in blogs and guides, which resolves the attached bug at mobile page widths. 

This is already done for the `learn images`, which are why those are fine on mobile.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/3150
