### PR TITLE
Fix title blog and guide title being blocked by navbar on mobile

### DIFF
--- a/docs/_layouts/guide.html
+++ b/docs/_layouts/guide.html
@@ -2,7 +2,7 @@
 <div class="row" id="post-row">
     <div class="col-xs-12 col-lg-1"></div>
     <div class="py-5 px-5 col-xs-12 col-lg-10">
-        <div class="cw-docs-spacer"></div>
+        <div class="cw-blog-spacer"></div>
         <div id="post-content">
             <h1>{{ page.title }}</h1>
             <p>{{ page.date | date_to_string }}</p>

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -2,7 +2,7 @@
 <div class="row" id="post-row">
     <div class="col-xs-12 col-lg-1"></div>
     <div class="py-5 px-5 col-xs-12 col-lg-10">
-        <div class="cw-docs-spacer"></div>
+        <div class="cw-blog-spacer"></div>
         <div id="post-content">
             <h1>{{ page.title }}</h1>
             <p>{{ page.date | date_to_string }} - {{ page.author }}</p>

--- a/docs/css/blog.css
+++ b/docs/css/blog.css
@@ -165,6 +165,10 @@ blockquote {
     margin-bottom: 0.25em;
 }
 
+.cw-blog-spacer {
+    height: 115px;
+}
+
 @media screen and (max-width: 600px) {
     .media {
         flex-direction: column;


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

The existing guide and blogs templates used the `cw-docs-spacer`, which is coded to reduce to height: 0 once the sidebar collapses... this is causing the title to be hidden by the navbar on the blogs and guides pages, as these don't have a sidebar. 

This PR adds a new spacer for these, which doesn't disappear at lower page widths. 

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/3156
