### PR TITLE
Add extra script to replicate publish

### DIFF
--- a/removeBuild.sh
+++ b/removeBuild.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Shut down apache
+echo "Shutting down apache server..."
+docker stop my-apache-app >/dev/null 2>&1
+
+echo "Removing apache container..."
+docker container rm my-apache-app >/dev/null 2>&1


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?

Adds an extra script to be run to test changes for the published site. This replicates using `jekyll build` to build the changes, and copying the built pages into an Apache container. 

This script is named `build.sh`, the existing `build.sh` has been moved to `runLinkchecker.sh`, as this is the extra step this script runs.

Also adds `removeBuild.sh` to be run to clean up the build container.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2727
