### PR TITLE
Fix overlap in nav bar

### DIFF
--- a/docs/_includes/header-fixedtop.html
+++ b/docs/_includes/header-fixedtop.html
@@ -13,7 +13,7 @@
         <!-- End Google Tag Manager (noscript) -->
     <div class="main">
     <!-- Bootstrap NavBar -->
-	<nav class="navbar navbar-expand-lg navbar-light cw-banner fixed-top" aria-label="topnav">
+	<nav class="navbar navbar-expand-xl navbar-light cw-banner fixed-top" aria-label="topnav">
     		{% include topbar.html %}
     	</nav>
     	<!-- End Bootstrap NavBar -->

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -13,7 +13,7 @@
         <!-- End Google Tag Manager (noscript) -->
     <div class="main">
     <!-- Bootstrap NavBar -->
-	<nav class="navbar navbar-expand-lg navbar-light cw-banner"  aria-label="topnav">
+	<nav class="navbar navbar-expand-xl navbar-light cw-banner"  aria-label="topnav">
     		{% include topbar.html %}
     	</nav>
     	<!-- End Bootstrap NavBar -->

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -54,7 +54,7 @@ code {
 
 .cw-header-logo {
     position: relative;
-    left: 70px;
+    padding-left: 20px;
 }
 .cw-header-link-text {
 	font-size: 16px;
@@ -65,22 +65,23 @@ code {
 	font-weight: 600;
 }
 .cw-header-link-news {
-	padding-right: 33px;
+	padding-right: 24px;
 }
 
 .cw-header-link-blog {
-	padding-right: 33px;
+	padding-right: 24px;
 }
 
 .cw-header-link-guides {
-	padding-right: 33px;
+	padding-right: 24px;
 }
 
 .cw-header-link-docs {
-	padding-right:45px;
+	padding-right:24px;
 }
+
 .cw-navbar-padding {
-    padding-right: 70px;
+    padding-right: 20px;
 }
 
 .cw-navbar-nav {
@@ -165,11 +166,11 @@ code {
 }
 
 #github-stars-button {
-    padding-left: 32px;
+    padding-left: 24px;
 }
 
 .cw-header-link {
-    padding-left: 32px;
+    padding-left: 24px;
 }
 
 #download-li {
@@ -655,6 +656,20 @@ code {
     }
 
     /* end hero section */
+
+    .cw-navbar-nav {
+        display: flex;
+    }
+
+    /* topbar logo */
+    .cw-header-logo {
+        position: unset;
+        left: unset;
+    }
+
+    .cw-banner {
+        height: unset;
+    }
 }
 
 /* Large devices (laptops/desktops, 992px and below) */
@@ -741,23 +756,10 @@ code {
     .cw-getting-started-col {
         padding-bottom: 40px;
     }
-    /* topbar logo */
-    .cw-header-logo {
-        position: unset;
-        left: unset;
-
-    }
 
     /* nav bar*/
     #github-stars-button {
         display: none;
-    }
-    .cw-banner {
-        height: unset;
-    }
-
-    .cw-navbar-nav {
-        display: flex;
     }
 
     .cw-header-link {


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Fixes bug where Codewind logo overlaps "learn" at middle page widths. 

Does this by increasing the breakpoint at which navbar collapses (992 -> 1200px), and also adjusting the padding within the navbar.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/3112
