### PR TITLE
Resolves #3171: Link to getting started overview from landing page

### DIFF
--- a/docs/learn.html
+++ b/docs/learn.html
@@ -50,6 +50,7 @@ redirect_from:
               <a href="vsc-getting-started.html">VS Code</a>,
               <a href="eclipse-getting-started.html">Eclipse</a>, or
               <a href="intellij-getting-started.html">IntelliJ</a>.
+              <a href="gettingstarted-overview.html">Read more</a> about local, remote and browser-based configurations.
             </p>
             <div
               class="col d-flex justify-content-start flex-column flex-xl-row"
@@ -100,6 +101,7 @@ redirect_from:
             <p>
               Download to develop, build and run entirely on the cloud,
               <a href="che-installinfo.html ">step-by-step instructions</a>.
+              <a href="gettingstarted-overview.html">Read more</a> about local, remote and browser-based configurations.
             </p>
             <div
               class="col d-flex justify-content-start flex-column flex-xl-row"

--- a/docs/learn.html
+++ b/docs/learn.html
@@ -50,7 +50,7 @@ redirect_from:
               <a href="vsc-getting-started.html">VS Code</a>,
               <a href="eclipse-getting-started.html">Eclipse</a>, or
               <a href="intellij-getting-started.html">IntelliJ</a>.
-              <a href="gettingstarted-overview.html">Read more</a> about local, remote and browser-based configurations.
+              <a href="gettingstarted-overview.html">Read more</a> about local, remote, and browser-based configurations.
             </p>
             <div
               class="col d-flex justify-content-start flex-column flex-xl-row"
@@ -101,7 +101,7 @@ redirect_from:
             <p>
               Download to develop, build and run entirely on the cloud,
               <a href="che-installinfo.html ">step-by-step instructions</a>.
-              <a href="gettingstarted-overview.html">Read more</a> about local, remote and browser-based configurations.
+              <a href="gettingstarted-overview.html">Read more</a> about local, remote, and browser-based configurations.
             </p>
             <div
               class="col d-flex justify-content-start flex-column flex-xl-row"


### PR DESCRIPTION
Signed-off-by: Alif Munim <alif.munim@ryerson.ca>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
In `learn.html`, add a link to `gettingstarted-overview.html` for users to read more about local, remote, and browser-based configurations.
![image](https://user-images.githubusercontent.com/59207653/85440027-9aae7f80-b55b-11ea-9388-837690a9d706.png)



## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/3171

## Does this PR require a documentation change ?
N/A

## Any special notes for your reviewer ?
N/A