### PR TITLE
Add link to che install page in Devops card on /learn

### DIFF
--- a/docs/learn.html
+++ b/docs/learn.html
@@ -162,9 +162,10 @@ redirect_from:
             </div>
             <p>
               If you are a sysadmin or DevOps engineer, learn how to
-              <a href="remote-deploying-codewind.html"
-                >deploy Codewind remotely</a
-              >.
+              <a href="remote-deploying-codewind.html">deploy Codewind remotely</a>, or learn how to
+              <a href="che-installinfo.html">
+                install Codewind for Eclipse Che
+              </a>.
             </p>
           </div>
         </div>


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Adds the extra link requested in the issue. This is to the Che install page from the Devops card within the job role specific section of /learn.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/3183

