### PR TITLE
#3171: Relocate link to gettingstarted-overview.html

### DIFF
--- a/docs/learn.html
+++ b/docs/learn.html
@@ -99,8 +99,8 @@ redirect_from:
           </div>
           <div class="card-body d-flex flex-column justify-content-between">
             <p>
-              Download to develop, build and run entirely on the cloud,
-              <a href="che-installinfo.html ">step-by-step instructions</a>.
+              Download to develop, build and run entirely on the cloud. Follow
+              <a href="che-installinfo.html ">step-by-step instructions</a> for Eclipse Che.
               Read more about <a href="gettingstarted-overview.html">local, remote, and browser-based configurations</a>.
             </p>
             <div

--- a/docs/learn.html
+++ b/docs/learn.html
@@ -50,7 +50,7 @@ redirect_from:
               <a href="vsc-getting-started.html">VS Code</a>,
               <a href="eclipse-getting-started.html">Eclipse</a>, or
               <a href="intellij-getting-started.html">IntelliJ</a>.
-              <a href="gettingstarted-overview.html">Read more</a> about local, remote, and browser-based configurations.
+              Read more about <a href="gettingstarted-overview.html">local, remote, and browser-based configurations</a>.
             </p>
             <div
               class="col d-flex justify-content-start flex-column flex-xl-row"
@@ -101,7 +101,7 @@ redirect_from:
             <p>
               Download to develop, build and run entirely on the cloud,
               <a href="che-installinfo.html ">step-by-step instructions</a>.
-              <a href="gettingstarted-overview.html">Read more</a> about local, remote, and browser-based configurations.
+              Read more about <a href="gettingstarted-overview.html">local, remote, and browser-based configurations</a>.
             </p>
             <div
               class="col d-flex justify-content-start flex-column flex-xl-row"


### PR DESCRIPTION
Signed-off-by: Alif Munim <alif.munim@ryerson.ca>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

* Relocate link to `gettingstarted-overview.html` in the **Desktop and remote** and **Browser based** cards 
  * **Before:** <a href="gettingstarted-overview.html">Read more</a> local, remote, and browser-based configurations.
  * **After:** Read more about <a href="gettingstarted-overview.html">local, remote, and browser-based configurations</a>.

![image](https://user-images.githubusercontent.com/59207653/85756737-15eb6f00-b6dd-11ea-96e2-23c92c1a2120.png)


## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/3171

## Does this PR require a documentation change ?
N/a

## Any special notes for your reviewer ?
N/a