### PR TITLE
Move OpenShift registry topic and signpost back

### DIFF
--- a/docs/_data/docstoc.yml
+++ b/docs/_data/docstoc.yml
@@ -64,8 +64,6 @@
     url: che-installinfo.html
   - title: '2. Adding an image registry in Codewind on Eclipse Che'
     url: che-setupregistries.html
-  - title: 'Optional: Adding the OpenShift internal registry with Codewind'
-    url: openshiftregistry.html
   - title: '3. Creating a Codewind workspace in Eclipse Che'
     url: che-createcodewindworkspace.html
   - title: '4. Creating your first Codewind project with Codewind for Eclipse Che'
@@ -93,6 +91,8 @@
       url: project-settings.html
     - title: 'Referencing files external to a project'
       url: referencing-files.html
+    - title: 'Adding the OpenShift internal registry with Codewind'
+      url: openshiftregistry.html
     - title: 'Developing with packages from private registries and repositories'
       url: private-registries.html
     - title: 'Linking your projects'

--- a/docs/_documentations/openshiftregistry.md
+++ b/docs/_documentations/openshiftregistry.md
@@ -74,3 +74,11 @@ Some of the following instructions were adapted from [Remotely Push and Pull Con
 5. Enter the token retrieved from the service account token secret as the `password`. 
 6. Enter `<project>` as `namespace`, where `<project>` is the OpenShift project where you created the service account. 
 7. Click **Enter**.
+
+### Next Steps
+
+You have added the OpenShift internal registry with Codewind. 
+
+Continue to instructions for how to use Codewind with Che workspaces to develop your application in a single location. For more information see [Creating a Codewind workspace in Che](che-createcodewindworkspace.html).
+
+Or create a project in VS Code or Eclipse that you can develop locally but build and run remotely. For more information, see [Creating and importing projects in VS Code](remotedeploy-projects-vscode.html) or [Creating and importing projects in Eclipse](remotedeploy-projects-eclipse.html).

--- a/docs/_documentations/openshiftregistry.md
+++ b/docs/_documentations/openshiftregistry.md
@@ -79,6 +79,6 @@ Some of the following instructions were adapted from [Remotely Push and Pull Con
 
 You have added the OpenShift internal registry with Codewind. 
 
-Continue to instructions for how to use Codewind with Che workspaces to develop your application in a single location. For more information see [Creating a Codewind workspace in Che](che-createcodewindworkspace.html).
+Continue to instructions for how to use Codewind with Che workspaces to develop your application in a single location. For more information, see [Creating a Codewind workspace in Che](che-createcodewindworkspace.html).
 
 Or create a project in VS Code or Eclipse that you can develop locally but build and run remotely. For more information, see [Creating and importing projects in VS Code](remotedeploy-projects-vscode.html) or [Creating and importing projects in Eclipse](remotedeploy-projects-eclipse.html).

--- a/docs/_documentations/openshiftregistry.md
+++ b/docs/_documentations/openshiftregistry.md
@@ -27,7 +27,7 @@ Some of the following instructions were adapted from [Remotely Push and Pull Con
 3. Grant push access to the registry to the new service account.
     - Run: `oc policy add-role-to-user system:image-builder system:serviceaccount:<project>:<serviceaccount>`
     - Example: `oc policy add-role-to-user system:image-builder system:serviceaccount:pushed:pusher`
-4. Retrieve the secret containing the service account token.
+4. Retrieve the secret that contains the service account token.
     - Run: `oc describe sa <serviceaccount>`
     - Example output:
        ```
@@ -42,7 +42,7 @@ Some of the following instructions were adapted from [Remotely Push and Pull Con
                             pusher-token-zfqbv
        Events:              <none>
        ```
-    - In this example, `pusher-token-hhd2g` and `pusher-token-zfqbv` are the secrets containing the service account token.
+    - In this example, `pusher-token-hhd2g` and `pusher-token-zfqbv` are the secrets that contain the service account token.
 5. Select one of the token secrets and retrieve the token from it.
     - Run: `oc describe secret <secret>`
     - Example output:
@@ -71,7 +71,7 @@ Some of the following instructions were adapted from [Remotely Push and Pull Con
 2. Run the command, `Codewind: Image Registry Manager`. 
 3. Enter `docker-registry.default.svc:5000` as the `Address` (`image-registry.openshift-image-registry.svc:5000` for OCP version 4). 
 4. Enter the service account name as the `username`.
-5. Enter the token retrieved from the service account token secret as the `password`. 
+5. Enter the token that is retrieved from the service account token secret as the `password`. 
 6. Enter `<project>` as `namespace`, where `<project>` is the OpenShift project where you created the service account. 
 7. Click **Enter**.
 


### PR DESCRIPTION
Signed-off-by: micgibso <MICGIBSO@uk.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [X ] Enhancement

## What does this PR do ?
Moves the OpenShift Registry topic into Developing projects section and signposts back to the Getting Started user workflows.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/3188

## Does this PR require a documentation change ?
Yes.

## Any special notes for your reviewer ?
Acrolinx checked and run locally. 