### PR TITLE
Correcting the name of Open API Tools (VS Code)

### DIFF
--- a/docs/_documentations/codewind-openapi-vscode.md
+++ b/docs/_documentations/codewind-openapi-vscode.md
@@ -1,17 +1,17 @@
 ---
 layout: docs
-title: Codewind OpenAPI Tools for VS Code
-description: How to work with the OpenAPI tools in VS Code
-keywords: install, run, open, import, show, restart, edit, build, logs, tools, eclipse, Codewind OpenAPI tools for VS Code
+title: Open API Tools for Eclipse Codewind in VS Code
+description: How to work with the Open API Tools for Eclipse Codewind in VS Code
+keywords: install, run, open, import, show, restart, edit, build, logs, tools, eclipse, Open API Tools for Eclipse Codewind in VS Code
 duration: 1 minute
 permalink: open-api-tools-for-vscode.html
 type: document
 order: 30
 ---
 
-# Codewind OpenAPI Tools for VS Code
+# Open API Tools for Eclipse Codewind in VS Code
 
-The Codewind OpenAPI Tools for VS Code provides commands that invoke the OpenAPI Generator to create API clients, server stubs, and HTML documentation from OpenAPI definitions. The tools are integrated and customized to work with Codewind for VS Code, but they can also work without the Codewind extension.
+The Open API Tools for Eclipse Codewind in VS Code provides commands that invoke the OpenAPI Generator to create API clients, server stubs, and HTML documentation from OpenAPI definitions. The tools are integrated and customized to work with Codewind for VS Code, but they can also work without the Codewind extension.
 
 ## Prerequisites
 - Install Docker before you run the generator. In VS Code, the plug-in pulls in the OpenAPI generator image from [Docker](https://github.com/OpenAPITools/openapi-generator#16---docker).
@@ -20,9 +20,9 @@ The Codewind OpenAPI Tools for VS Code provides commands that invoke the OpenAPI
 1. Install [VS Code version 1.27 or later](https://code.visualstudio.com/download).
 2. (OPTIONAL) Install Codewind for VS Code from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=IBM.codewind) or by searching for `Codewind` in the [VS Code Extensions view](https://code.visualstudio.com/docs/editor/extension-gallery#_browse-for-extensions).
 3. This extension pulls the [OpenAPI Generator CLI Docker Image](https://github.com/OpenAPITools/openapi-generator#16---docker) and runs the OpenAPI Generator in a Docker container. Install Docker if necessary.
-4. Install the Codewind OpenAPI Tools from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=IBM.codewind-openapi-tools) or by searching for `Codewind OpenAPI` in the [VS Code Extensions view](https://code.visualstudio.com/docs/editor/extension-gallery#_browse-for-extensions).
+4. Install the Open API Tools for Eclipse Codewind from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=IBM.codewind-openapi-tools) or by searching for `Codewind OpenAPI` in the [VS Code Extensions view](https://code.visualstudio.com/docs/editor/extension-gallery#_browse-for-extensions).
 
-## Generating and building client and server stubs by using the OpenAPI tools
+## Generating and building client and server stubs by using the Open API Tools for Eclipse Codewind
 1. Right-click your Codewind project from the Codewind view and select either the **Generate Server from OpenAPI Definition** menu or **Generate Client from OpenAPI Definition** action. You are then prompted to provide options to the OpenAPI generator.
 2. Select your OpenAPI document file. The file must be a valid OpenAPI 3.0 `.yaml` or `.json` file that is in the project.
 3. Select the client or server generator type.
@@ -33,7 +33,7 @@ The Codewind OpenAPI Tools for VS Code provides commands that invoke the OpenAPI
 8. Now, you can customize the application logic. Choose one of the two methods in the **Generating and building code in an existing Java Spring project** section.
 
 ## Generating and building code in an existing Java Spring project
-When you generate a Spring server stub into a Spring project, the OpenAPI tools for VS Code don't override the main class that is already implicitly or explicitly configured in the project. Complete one of the following steps to expose the OpenAPI endpoints:
+When you generate a Spring server stub into a Spring project, the Open API Tools for Eclipse Codewind in VS Code don't override the main class that is already implicitly or explicitly configured in the project. Complete one of the following steps to expose the OpenAPI endpoints:
 - To use the generated class, uncomment the main method in the `OpenAPI2SpringBoot.java` Java class file and explicitly configure the project to use this main class.
 - To continue to use the currently configured main class, copy the base packages that are listed in the `@ComponentScan` component scan annotation from the `OpenAPI2SpringBoot.java` file. Then, add the packages to the currently configured main class. For example, if you use the Codewind Spring Boot project, the implicit main class is the `SBApplication.java` file.
 

--- a/docs/_documentations/codewind-openapi-vscode.md
+++ b/docs/_documentations/codewind-openapi-vscode.md
@@ -33,7 +33,7 @@ The Open API Tools for Eclipse Codewind in VS Code provides commands that invoke
 8. Now, you can customize the application logic. Choose one of the two methods in the **Generating and building code in an existing Java Spring project** section.
 
 ## Generating and building code in an existing Java Spring project
-When you generate a Spring server stub into a Spring project, the Open API Tools for Eclipse Codewind in VS Code don't override the main class that is already implicitly or explicitly configured in the project. Complete one of the following steps to expose the OpenAPI endpoints:
+When you generate a Spring server stub into a Spring project, Open API Tools for Eclipse Codewind doesn't override the main class that is already implicitly or explicitly configured in the project. Complete one of the following steps to expose the OpenAPI endpoints:
 - To use the generated class, uncomment the main method in the `OpenAPI2SpringBoot.java` Java class file and explicitly configure the project to use this main class.
 - To continue to use the currently configured main class, copy the base packages that are listed in the `@ComponentScan` component scan annotation from the `OpenAPI2SpringBoot.java` file. Then, add the packages to the currently configured main class. For example, if you use the Codewind Spring Boot project, the implicit main class is the `SBApplication.java` file.
 


### PR DESCRIPTION
Remove any reference to Codewind API Tools from the docs. The correct name is "Open API Tools for Eclipse Codewind."